### PR TITLE
Flag specs with obsolete WebIDL Level 1 constructs in crawl report

### DIFF
--- a/crawl-specs.js
+++ b/crawl-specs.js
@@ -151,9 +151,15 @@ function crawlList(speclist) {
                 spec,
                 titleExtractor(dom),
                 refParser.extract(dom).catch(err => {console.error(url, err); return err;}),
-                webidlExtractor.extract(dom).then(idl => webidlParser.parse(idl)).catch(err => {console.error(url, err); return err;}),
+                webidlExtractor.extract(dom)
+                    .then(idl => Promise.all([
+                        webidlParser.parse(idl),
+                        webidlParser.hasObsoleteIDL(idl)
+                    ])
+                    .then(res => { res[0].hasObsoleteIDL = res[1]; return res[0] })
+                    .catch(err => { console.error(url, err); return [err, null]; })),
                 dom
-                    ]))
+            ]))
             .then(res => {
                 const spec = res[0];
                 const doc = res[4].document;

--- a/parse-webidl.js
+++ b/parse-webidl.js
@@ -5,6 +5,24 @@ function normalizeWebIDL1to2(idl) {
 }
 
 /**
+ * Checks whether the given IDL uses WebIDL Level 1 constructs that are no
+ * longer valid in WebIDL Level 2.
+ *
+ * Note a smarter method would typically return the list of obsolete constructs
+ * instead of just a boolean flag. To be considered...
+ *
+ * @function
+ * @public
+ * @param {String} idl IDL content to check
+ * @return {boolean} True when the IDL string contains obsolete constructs,
+ *   false otherwise.
+ */
+function hasObsoleteIDL(idl) {
+    return (idl !== normalizeWebIDL1to2(idl));
+}
+
+
+/**
  * Main method that takes IDL definitions and parses that IDL to compute
  * the list of internal/external dependencies.
  *
@@ -347,6 +365,7 @@ function replaceFakePrimaryGlobal(primaryGlobal, jsNames) {
 Export the parse method for use as module
 **************************************************/
 module.exports.parse = parse;
+module.exports.hasObsoleteIDL = hasObsoleteIDL;
 
 
 /**************************************************


### PR DESCRIPTION
Some specs still use `[]` instead of `FrozenArray`. Our WebIDL parser automatically updates these definitions to be able to process the WebIDL.

The fact that this had to be done is now reported in an `hasObsoleteIDL` property.

Note that this property is just a boolean for now. Ideally, it would list the exact IDL definitions that need to be fixed.