### PR TITLE
Handle parsing types of multi-type generics

### DIFF
--- a/parse-webidl.js
+++ b/parse-webidl.js
@@ -270,7 +270,7 @@ function parseType(idltype, idlNames, externalDependencies, contextName) {
     if (isString(idltype)) {
         idltype = { idlType: 'DOMString' };
     }
-    if (idltype.union) {
+    if (idltype.union || (idltype.generic && Array.isArray(idltype.idlType))) {
         idltype.idlType.forEach(t => parseType(t, idlNames, externalDependencies, contextName));
         return;
     }


### PR DESCRIPTION
e.g. record<DOMString,Foo> - so far, the code assumed generics only took one parameter