### PR TITLE
Report specs that could not be parsed separately

### DIFF
--- a/crawl-specs.js
+++ b/crawl-specs.js
@@ -109,7 +109,8 @@ function getSpecFromW3CApi(spec) {
         .then(s => {
             const versions = s._embedded['version-history'].map(v => v.uri);
             const editors = s._embedded['version-history'].map(v => v['editors-draft']).filter((u,i,a) => u && a.indexOf(u) == i);
-            const latest = s._embedded['version-history'][0]
+            const latest = s._embedded['version-history'][0];
+            spec.title = latest.title;
             if (!spec.latest) spec.latest = (latest['editor-draft'] ? latest['editor-draft'] : latest.uri);
             spec.versions = new Set([...spec.versions, ...versions, ...editors]);
             return spec;
@@ -162,9 +163,9 @@ function crawlList(speclist) {
                 webidlExtractor.extract(dom)
                     .then(idl => Promise.all([
                         webidlParser.parse(idl),
-                        webidlParser.hasObsoleteIDL(idl)
+                        webidlParser.hasObsoleteIdl(idl)
                     ])
-                    .then(res => { res[0].hasObsoleteIDL = res[1]; return res[0] })
+                    .then(res => { res[0].hasObsoleteIdl = res[1]; return res[0] })
                     .catch(err => { console.error(url, err); return [err, null]; })),
                 dom
             ]))
@@ -176,7 +177,7 @@ function crawlList(speclist) {
                     statusAndDateElement.textContent.split(/\s+/).slice(-3).join(' ') :
                     (new Date(Date.parse(doc.lastModified))).toDateString());
 
-                spec.title = spec.title ? spec.title : res[1];
+                spec.title = res[1] ? res[1] : spec.title;
                 spec.date = date;
                 spec.refs = res[2];
                 spec.idl = res[3];
@@ -185,7 +186,7 @@ function crawlList(speclist) {
             })
             .catch(err => {
                 spec.error = err.toString();
-                spec.title = "";
+                spec.title = spec.title || "";
                 spec.date = "";
                 spec.refs = {};
                 spec.idl = {};

--- a/parse-webidl.js
+++ b/parse-webidl.js
@@ -17,7 +17,7 @@ function normalizeWebIDL1to2(idl) {
  * @return {boolean} True when the IDL string contains obsolete constructs,
  *   false otherwise.
  */
-function hasObsoleteIDL(idl) {
+function hasObsoleteIdl(idl) {
     return (idl !== normalizeWebIDL1to2(idl));
 }
 
@@ -365,7 +365,7 @@ function replaceFakePrimaryGlobal(primaryGlobal, jsNames) {
 Export the parse method for use as module
 **************************************************/
 module.exports.parse = parse;
-module.exports.hasObsoleteIDL = hasObsoleteIDL;
+module.exports.hasObsoleteIdl = hasObsoleteIdl;
 
 
 /**************************************************

--- a/study-specs.js
+++ b/study-specs.js
@@ -37,6 +37,7 @@ function processReport(results) {
             var idlDeps = (spec.idl && spec.idl.externalDependencies) ?
                 spec.idl.externalDependencies : [];
             var report = {
+                error: spec.error,
                 hasNormativeRefs: (spec.refs.normative &&
                     (spec.refs.normative.length > 0)),
                 referencesWebIDL: (spec.refs.normative &&
@@ -84,9 +85,11 @@ function processReport(results) {
                     })
                     .filter(i => !!i)
             };
-            report.ok = report.hasNormativeRefs &&
+            report.ok = !report.error &&
+                report.hasNormativeRefs &&
                 report.hasIdl &&
                 !report.hasInvalidIdl &&
+                !report.hasObsoleteIdl &&
                 report.referencesWebIDL &&
                 (!report.unknownIdlNames || (report.unknownIdlNames.length === 0)) &&
                 (!report.redefinedIdlNames || (report.redefinedIdlNames.length === 0)) &&
@@ -127,10 +130,25 @@ function generateReportPerSpec(results) {
     w();
     w();
 
+    let parsingErrors = results.filter(spec => spec.report.error);
+    if (parsingErrors.length > 0) {
+        w('## Specifications that could not be parsed');
+        w();
+        count = 0;
+        parsingErrors.forEach(spec => {
+            count += 1;
+            w('- [' + spec.title + '](' + (spec.latest || spec.url) + ')');
+        });
+        w();
+        w('=> ' + count + ' specification' + ((count > 1) ? 's' : '') + ' found');
+        w();
+        w();
+    }
+
     w('## Specifications with possible issues');
     w();
     results
-        .filter(spec => !spec.report.ok)
+        .filter(spec => !spec.report.ok && !spec.report.error)
         .forEach(spec => {
             w('### ' + spec.title);
             w();
@@ -153,6 +171,9 @@ function generateReportPerSpec(results) {
             }
             if (report.hasInvalidIdl) {
                 w('- Invalid WebIDL content found');
+            }
+            if (report.hasObsoleteIdl) {
+                w('- Obsolete WebIDL constructs found');
             }
             if (report.hasIdl && !report.referencesWebIDL) {
                 w('- Spec uses WebIDL but does not reference it normatively');
@@ -203,6 +224,24 @@ function generateReport(results) {
     w();
     w();
 
+    let parsingErrors = results.filter(spec => spec.report.error);
+    if (parsingErrors.length > 0) {
+        w('## Specifications that could not be parsed');
+        w();
+        count = 0;
+        parsingErrors.forEach(spec => {
+            count += 1;
+            w('- [' + spec.title + '](' + (spec.latest || spec.url) + ')');
+        });
+        w();
+        w('=> ' + count + ' specification' + ((count > 1) ? 's' : '') + ' found');
+        w();
+        w();
+
+        // Remove specs that could not be parsed from the rest of the report
+        results = results.filter(spec => !spec.report.error);
+    }
+
     count = 0;
     w('## Specifications without normative dependencies');
     w();
@@ -246,6 +285,20 @@ function generateReport(results) {
     w('=> ' + count + ' specification' + ((count > 1) ? 's' : '') + ' found');
     w();
     w('**NB:** this may be due to WebIDL having evolved in the meantime');
+    w();
+    w();
+
+    count = 0;
+    w('## List of specifications with obsolete WebIDL constructs');
+    w();
+    results
+        .filter(spec => spec.report.hasObsoleteIdl)
+        .forEach(spec => {
+            count += 1;
+            w('- [' + spec.title + '](' + (spec.latest || spec.url) + ')');
+        });
+    w();
+    w('=> ' + count + ' specification' + ((count > 1) ? 's' : '') + ' found');
     w();
     w();
 


### PR DESCRIPTION
Reports now also list specs that contain obsolete IDL constructs.

The rules used to extract the title of a spec have been slightly adjusted:
1. the title is first retrieved from the W3C API when possible. This means we now have human friendly title even if we cannot parse the spec afterwards.
2. the title is then updated with the title found in the Editor's Draft when present.