### PR TITLE
First stab at dependencies report

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To launch the crawler and the report study tool, follow these steps:
 2. From the root folder of reffy, install required dependencies: `npm install`
 3. Create a `config.json` file, initialized with `{ "w3cApiKey": [API key] }`
 3. Run the crawler: `node crawl-specs.js ./specs-w3c.json results.json`
-4. Once done, run the study tool: `node study-specs.js ./results.json [true]` (pass `true` to create a report per specification instead of a report per anomaly). You may want to redirect the output to a file, e.g. using `node study-specs.js ./results.json > report.md`
+4. Once done, run the study tool: `node study-specs.js ./results.json [perspec|dep]` (pass `perspec` to create a report per specification instead of a report per anomaly and `dep` to generate a dependencies report). You may want to redirect the output to a file, e.g. using `node study-specs.js ./results.json > report.md`
 
 Some notes:
 

--- a/study-specs.js
+++ b/study-specs.js
@@ -22,17 +22,8 @@ function processReport(results) {
     // TODO: we may end up with different variants of the WebIDL spec
     var WebIDLSpec = results.find(spec => (spec.shortname === 'WebIDL-1')) || {};
 
-    var sortedResults = results.sort((a, b) => {
-        var A = a.title.toUpperCase();
-        var B = b.title.toUpperCase();
-        if (A < B) {
-            return -1;
-        }
-        if (A > B) {
-            return 1;
-        }
-        return 0;
-    });
+    var sortedResults = results.sort((a,b) =>
+        a.title.toUpperCase().localeCompare(b.title.toUpperCase()));
 
     return sortedResults
         .map(spec => {


### PR DESCRIPTION
This PR addresses #26 and adds a dependencies report to the study tool, triggered when the console parameter is "dep". That dependencies report lists specs that got crawled. For each of them, the report lists the specs that reference it either normatively or informatively.

The report could be further improved. It could for instance clarify what version of the spec the reference targets (ED, version number when available, dated spec, generic TR spec, etc.). It could also list the references that are currently missing but that should exist (one of the anomalies that we report in other reports).