### PR TITLE
Drop the ElementTraversal specification from crawl results

### DIFF
--- a/specs-common.json
+++ b/specs-common.json
@@ -1,7 +1,6 @@
 [
     "https://www.w3.org/TR/CSP3/",
     "https://www.w3.org/TR/DOM-Parsing/",
-    "https://www.w3.org/TR/ElementTraversal/",
     "https://www.w3.org/TR/FileAPI/",
     "https://www.w3.org/TR/IndexedDB-2/",
     "https://www.w3.org/TR/SVG2/",


### PR DESCRIPTION
The ElementTraversal Recommendation is now incorporated in the DOM spec (both the W3C and WHATWG version) and the ElementTraversal spec is not referenced from any other spec.

Executes order #66.