### PR TITLE
Fix "No IDL content" logic, broken by previous commit

### DIFF
--- a/study-specs.js
+++ b/study-specs.js
@@ -89,11 +89,14 @@ function processReport(results) {
 
     return sortedResults
         .map(spec => {
-            var idlDfns = (spec.idl && spec.idl.idlNames) ?
+            spec.idl = spec.idl || {};
+            var idlDfns = spec.idl.idlNames ?
                 Object.keys(spec.idl.idlNames).filter(name => (name !== '_dependencies') && (name !== '_reallyDependsOnWindow')) : [];
-            var idlDeps = (spec.idl && spec.idl.externalDependencies) ?
+            var idlExtendedDfns = spec.idl.idlExtendedNames ?
+                Object.keys(spec.idl.idlExtendedNames) : [];
+            var idlDeps = spec.idl.externalDependencies ?
                 spec.idl.externalDependencies : [];
-            var reallyDependsOnWindow = (spec.idl && spec.idl.idlNames) ?
+            var reallyDependsOnWindow = spec.idl.idlNames ?
                 spec.idl.idlNames._reallyDependsOnWindow : false;
 
             var report = {
@@ -117,9 +120,7 @@ function processReport(results) {
                 // (most specs crawled here should)
                 noIdlContent: (Object.keys(spec.idl).length === 0) ||
                     (!spec.idl.idlNames && !spec.idl.message) ||
-                    (spec.idl.idlNames &&
-                        (Object.keys(spec.idl.idlNames).length === 1) &&
-                        (Object.keys(spec.idl.idlExtendedNames).length === 0)),
+                    ((idlDfns.length === 0) && (idlExtendedDfns.length === 0)),
 
                 // Whether the spec has invalid IDL content
                 // (the crawler cannot do much when IDL content is invalid, it


### PR DESCRIPTION
Last commit - https://github.com/tidoust/reffy/commit/cfb12664968cee09b16193d9d76f3609ea0f3bd5 - introduced a `_reallyDependsOnWindow` internal key in the `idl` object to create an exception to the rule for `Window`.

However, the logic that set the "No IDL content" flag relied on the number of keys in the `idl` object, assuming there would be only one internal key. The net result is that Reffy started to report that specs that do not define any IDL content miss a normative reference to WebIDL, which is incorrect.

This was missed in previous commit because that logic was not explicit that it was taking internal keys into account. The logic was fixed and is now explicit.