### PR TITLE
Take IDL index appendix into account in ReSpec specs too

### DIFF
--- a/extract-webidl.js
+++ b/extract-webidl.js
@@ -80,10 +80,16 @@ function extractBikeshedIdl(doc) {
  */
 function extractRespecIdl(doc) {
     return new Promise(resolve => {
-        var idl = "";
-        ["pre.idl", "pre > code.idl-code", "div.idl-code > pre", "pre.widl"]
-            .find(sel => !!(idl += [...doc.querySelectorAll(sel)].map(n => "\n" + n.textContent).join('')));
-        resolve(idl);
+        let idlEl = doc.querySelector('#idl-index pre');
+        if (idlEl) {
+            resolve(idlEl.textContent);
+        }
+        else {
+            let idl = '';
+            ['pre.idl', 'pre > code.idl-code', 'div.idl-code > pre', 'pre.widl']
+                .find(sel => !!(idl += [...doc.querySelectorAll(sel)].map(n => '\n' + n.textContent).join('')));
+            resolve(idl);
+        }
     });
 }
 


### PR DESCRIPTION
ReSpec can now automatically generate an IDL index appendix that contains the IDL content defined by the spec. The WebIDL extractor was not aware of this, extracted the IDL content from that appendix too, and ended up with duplicated IDL content, which in turn made the IDL parser report an "Already seen this definition" error.

The WebIDL extractor now uses the content of the appendix when defined.

An example of a spec with an IDL index appendix is the Web App Manifest spec:
https://w3c.github.io/manifest/#idl-index