### PR TITLE
Warn when W3C spec does not link to an Editor's Draft

### DIFF
--- a/crawl-specs.js
+++ b/crawl-specs.js
@@ -256,7 +256,7 @@ function crawlList(speclist, crawlOptions) {
 
     function getRefAndIdl(spec) {
         spec.title = spec.title || (spec.shortname ? spec.shortname : spec.url);
-        var bogusEditorDraft = ['webmessaging', 'eventsource', 'webstorage', 'progress-events', 'uievents'];
+        var bogusEditorDraft = ['webmessaging', 'eventsource', 'webstorage', 'progress-events'];
         var unparseableEditorDraft = [];
         spec.crawled = ((
                 crawlOptions.publishedVersion ||

--- a/generate-report.js
+++ b/generate-report.js
@@ -214,6 +214,9 @@ function generateReportPerSpec(study) {
                 ' report.');
         }
         else {
+            if (report.noEdDraft) {
+                w('- Link to an Editor\'s Draft not found');
+            }
             if (report.noNormativeRefs) {
                 w('- No normative references found');
             }
@@ -323,6 +326,29 @@ function generateReportPerIssue(study) {
         // Remove specs that could not be parsed from the rest of the report
         results = results.filter(spec => !spec.report.error);
     }
+
+
+    count = 0;
+    w('## Specifications that do not link to an Editor\'s Draft');
+    w();
+    results
+        .filter(spec => spec.report.noEdDraft)
+        .forEach(spec => {
+            count += 1;
+            w('- [' + spec.title + '](' + spec.crawled + ')');
+        });
+    w();
+    w('=> ' + count + ' specification' + ((count > 1) ? 's' : '') + ' found');
+    if (count > 0) {
+        w();
+        w('It is good practice to link to Editor\'s Draft for W3C specifications ' +
+            'even for specifications published as Recommendations. Reffy (or ' +
+            'rather the W3C API) could not find a link to an Editor\'s Draft ' +
+            'for the specifications mentioned above.');
+    }
+    w();
+    w();
+
 
     count = 0;
     w('## Specifications without normative dependencies');
@@ -701,6 +727,7 @@ function generateDiffReport(study, refStudy, options) {
             } : null,
             ok: getSimpleDiff('ok'),
             error: getSimpleDiff('error'),
+            noEdDraft: getSimpleDiff('noEdDraft'),
             noNormativeRefs: getSimpleDiff('noNormativeRefs'),
             noRefToWebIDL: getSimpleDiff('noRefToWebIDL'),
             noIdlContent: getSimpleDiff('noIdlContent'),
@@ -823,6 +850,7 @@ function generateDiffReport(study, refStudy, options) {
             { title: 'Spec title', prop: 'title', diff: 'simple' },
             { title: 'Spec is OK', prop: 'ok', diff: 'simple' },
             { title: 'Spec could not be rendered', prop: 'error', diff: 'simple' },
+            { title: 'Link to an Editor\'s Draft not found', prop: 'noEdDraft', diff: 'simple' },
             { title: 'No normative references found', prop: 'noNormativeRefs', diff: 'simple' },
             { title: 'No WebIDL definitions found', prop: 'noIdlContent', diff: 'simple' },
             { title: 'Invalid WebIDL content found', prop: 'hasInvalidIdl', diff: 'simple' },

--- a/report-template.html
+++ b/report-template.html
@@ -46,6 +46,7 @@
       <option selected="selected" value="all">All</option>
       <option value="ok">Specs without issues</option>
       <option value="error">Specs that could not be rendered</option>
+      <option value="noEdDraft">Specs that do not link to an Editor's Draft</option>
       <option value="noNormativeRefs">Specs without normative references</option>
       <option value="hasInvalidIdl|hasObsoleteIdl">Specs with invalid WebIDL content</option>
       <option value="unknownIdlNames|redefinedIdlNames">Specs with problematic WebIDL terms</option>

--- a/study-crawl.js
+++ b/study-crawl.js
@@ -20,6 +20,7 @@
  * and in the list of references (e.g. because the body of the document
  * references the Editor's draft while the reference is to the latest published
  * version).
+ * 10. W3C specs that do not have a known Editor's Draft
  *
  * The crawl analyzer can be called directly through:
  *
@@ -275,7 +276,11 @@ function studyCrawlResults(results, specsToInclude) {
                             canonicalizesTo(r.url, spec.url, useEquivalents) ||
                             canonicalizesTo(r.url, spec.versions, useEquivalents)))
                         .map(filterSpecInfo)
-                }
+                },
+
+                // Warn when a W3C spec does not link to an Editor's Draft
+                noEdDraft: spec.url.match(/www.w3.org\/TR\//) &&
+                    !spec.edDraft
             };
 
             // A spec is OK if it does not contain anything "suspicious".
@@ -289,7 +294,8 @@ function studyCrawlResults(results, specsToInclude) {
                 (!report.redefinedIdlNames || (report.redefinedIdlNames.length === 0)) &&
                 (!report.missingWebIdlRef || (report.missingWebIdlRef.length === 0)) &&
                 (report.missingLinkRef.length === 0) &&
-                (report.inconsistentRef.length === 0);
+                (report.inconsistentRef.length === 0) &&
+                !report.noEdDraft;
             var res = {
                 title: spec.title,
                 shortname: spec.shortname,


### PR DESCRIPTION
Warn when W3C spec does not link to an Editor's Draft

The analysis now reports a warning when the W3C API did not return the URL of an Editor's Draft. In turn, this should mean that the spec does not include such a link, or that it does not include it along with the "this version" et al. links.

Fixes #104.

The Pull Request also drops UI Events from the list of specs with bogus links to an Editor's Draft: the link to the Editor's Draft is still bogus in the latest published version of the spec, but the URL returned by the W3C API is correct.