### PR TITLE
[Crawl] Crawl each spec in a separate child process

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -340,12 +340,6 @@ async function crawlList(speclist, crawlOptions, resultsPath) {
         return new Promise(resolve => {
             let resolved = false;
 
-            let timeout = setTimeout(_ => {
-                console.warn(spec.url, 'Crawl timeout');
-                reportError(new Error('Crawl took too long'));
-                child.kill();
-            }, 60000);
-
             function reportSuccess(result) {
                 if (resolved) {
                     console.warn('Got a second resolution for crawl in a child process');
@@ -383,6 +377,13 @@ async function crawlList(speclist, crawlOptions, resultsPath) {
                     reportError(new Error(`Crawl exited without sending result`));
                 }
             });
+
+            let timeout = setTimeout(_ => {
+                console.warn(spec.url, 'Crawl timeout');
+                reportError(new Error('Crawl took too long'));
+                child.kill();
+            }, 60000);
+
             child.send(spec);
         });
     }

--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -22,6 +22,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { fork } = require('child_process');
 const refParser = require('./parse-references');
 const webidlExtractor = require('./extract-webidl');
 const loadSpecification = require('../lib/util').loadSpecification;
@@ -223,7 +224,7 @@ function completeWithInfoFromSpecref(specs) {
  * @return {Promise<Array(Object)} The promise to get a list of spec
  *  descriptions.
  */
-function createInitialSpecDescriptions(list) {
+async function createInitialSpecDescriptions(list) {
     function createSpecObject(spec) {
         let res = {
             url: (typeof spec === 'string') ? spec : (spec.url || 'about:blank')
@@ -243,89 +244,185 @@ function createInitialSpecDescriptions(list) {
 
 
 /**
+ * Load and parse the given spec.
+ *
+ * @function
+ * @param {Object} spec The spec to load (must already have been completed with
+ *   useful info, as returned by "createInitialSpecDescriptions")
+ * @param {Object} crawlOptions Crawl options
+ * @return {Promise<Object>} The promise to get a spec object with crawl info
+ */
+async function crawlSpec(spec, crawlOptions) {
+    spec.title = spec.title || (spec.shortname ? spec.shortname : spec.url);
+    var bogusEditorDraft = ['webmessaging', 'eventsource', 'webstorage', 'progress-events'];
+    var unparseableEditorDraft = [];
+    spec.crawled = ((
+            crawlOptions.publishedVersion ||
+            bogusEditorDraft.includes(spec.shortname) ||
+            unparseableEditorDraft.includes(spec.shortname)) ?
+        spec.datedUrl || spec.latest || spec.url :
+        spec.edDraft || spec.url);
+    spec.date = "";
+    spec.links = [];
+    spec.refs = {};
+    spec.idl = {};
+    if (spec.error) {
+        return spec;
+    }
+    return loadSpecification({ html: spec.html, url: spec.crawled })
+        .then(dom => Promise.all([
+            spec,
+            titleExtractor(dom),
+            linkExtractor(dom),
+            refParser.extract(dom).catch(err => {
+                console.error(spec.crawled, err);
+                return err;
+            }),
+            webidlExtractor.extract(dom)
+                .then(idl =>
+                    Promise.all([
+                        idl,
+                        webidlParser.parse(idl),
+                        webidlParser.hasObsoleteIdl(idl)
+                    ])
+                    .then(([idl, parsedIdl, hasObsoletedIdl]) => {
+                        parsedIdl.hasObsoleteIdl = hasObsoletedIdl;
+                        parsedIdl.idl = idl;
+                        return parsedIdl;
+                    })
+                    .catch(err => {
+                        // IDL content is invalid and cannot be parsed.
+                        // Let's return the error, along with the raw IDL
+                        // content so that it may be saved to a file.
+                        console.error(spec.crawled, err);
+                        err.idl = idl;
+                        return err;
+                    })),
+            dom
+        ]))
+        .then(res => {
+            const spec = res[0];
+            const doc = res[5].document;
+            const statusAndDateElement = doc.querySelector('.head h2');
+            const date = (statusAndDateElement ?
+                statusAndDateElement.textContent.split(/\s+/).slice(-3).join(' ') :
+                (new Date(Date.parse(doc.lastModified))).toDateString());
+
+            spec.title = res[1] ? res[1] : spec.title;
+            spec.date = date;
+            spec.links = res[2];
+            spec.refs = res[3];
+            spec.idl = res[4];
+            res[5].close();
+            return spec;
+        })
+        .catch(err => {
+            spec.error = err.toString() + (err.stack ? ' ' + err.stack : '');
+            return spec;
+        });
+}
+
+
+/**
  * Main method that crawls the list of specification URLs and return a structure
  * that full describes its title, URLs, references, and IDL definitions.
  *
  * @function
  * @param {Array(String)} speclist List of URLs to parse
+ * @param {Object} crawlOptions Crawl options
  * @return {Promise<Array(Object)} The promise to get an array of complete
  *   specification descriptions
  */
-function crawlList(speclist, crawlOptions) {
+async function crawlList(speclist, crawlOptions, resultsPath) {
     crawlOptions = crawlOptions || {};
 
-    function getRefAndIdl(spec) {
-        spec.title = spec.title || (spec.shortname ? spec.shortname : spec.url);
-        var bogusEditorDraft = ['webmessaging', 'eventsource', 'webstorage', 'progress-events'];
-        var unparseableEditorDraft = [];
-        spec.crawled = ((
-                crawlOptions.publishedVersion ||
-                bogusEditorDraft.includes(spec.shortname) ||
-                unparseableEditorDraft.includes(spec.shortname)) ?
-            spec.datedUrl || spec.latest || spec.url :
-            spec.edDraft || spec.url);
-        spec.date = "";
-        spec.links = [];
-        spec.refs = {};
-        spec.idl = {};
-        if (spec.error) {
-            return spec;
-        }
-        return loadSpecification({ html: spec.html, url: spec.crawled })
-            .then(dom => Promise.all([
-                spec,
-                titleExtractor(dom),
-                linkExtractor(dom),
-                refParser.extract(dom).catch(err => {
-                    console.error(spec.crawled, err);
-                    return err;
-                }),
-                webidlExtractor.extract(dom)
-                    .then(idl =>
-                        Promise.all([
-                            idl,
-                            webidlParser.parse(idl),
-                            webidlParser.hasObsoleteIdl(idl)
-                        ])
-                        .then(([idl, parsedIdl, hasObsoletedIdl]) => {
-                            parsedIdl.hasObsoleteIdl = hasObsoletedIdl;
-                            parsedIdl.idl = idl;
-                            return parsedIdl;
-                        })
-                        .catch(err => {
-                            // IDL content is invalid and cannot be parsed.
-                            // Let's return the error, along with the raw IDL
-                            // content so that it may be saved to a file.
-                            console.error(spec.crawled, err);
-                            err.idl = idl;
-                            return err;
-                        })),
-                dom
-            ]))
-            .then(res => {
-                const spec = res[0];
-                const doc = res[5].document;
-                const statusAndDateElement = doc.querySelector('.head h2');
-                const date = (statusAndDateElement ?
-                    statusAndDateElement.textContent.split(/\s+/).slice(-3).join(' ') :
-                    (new Date(Date.parse(doc.lastModified))).toDateString());
+    async function crawlSpecInChildProcess(spec) {
+        return new Promise(resolve => {
+            let resolved = false;
 
-                spec.title = res[1] ? res[1] : spec.title;
-                spec.date = date;
-                spec.links = res[2];
-                spec.refs = res[3];
-                spec.idl = res[4];
-                res[5].close();
-                return spec;
-            })
-            .catch(err => {
-                spec.error = err.toString() + (err.stack ? ' ' + err.stack : '');
-                return spec;
+            let timeout = setTimeout(_ => {
+                console.warn(spec.url, 'Crawl timeout');
+                reportError(new Error('Crawl took too long'));
+                child.kill();
+            }, 60000);
+
+            function reportSuccess(result) {
+                if (resolved) {
+                    console.warn('Got a second resolution for crawl in a child process');
+                    return;
+                }
+                resolved = true;
+                clearTimeout(timeout);
+                resolve(result);
+            }
+
+            function reportError(err) {
+                if (resolved) {
+                    console.warn('Got a second error for crawl in a child process');
+                    return;
+                }
+                resolved = true;
+                resolve(Object.assign(spec, {
+                    error: err.toString() + (err.stack ? ' ' + err.stack : '')
+                }));
+            }
+
+            // Spawn a child process
+            // NB: passing the spec URL is useless but gives useful info when
+            // looking at processes during debugging in the task manager
+            let child = fork('src/cli/crawl-specs.js', [
+                    '--child', spec.url, (crawlOptions.publishedVersion ? 'tr' : 'ed')
+                ]);
+            child.once('message', result => reportSuccess(result));
+            child.once('exit', code => {
+                clearTimeout(timeout);
+                if (code && (code !== 0)) {
+                    reportError(new Error(`Crawl exited with code ${code}`));
+                }
+                else if (!resolved) {
+                    reportError(new Error(`Crawl exited without sending result`));
+                }
             });
+            child.send(spec);
+        });
     }
 
     return createInitialSpecDescriptions(speclist)
-        .then(list => Promise.all(list.map(getRefAndIdl)));
+        .then(list => {
+            // Process specs in chunks not to create too many child processes
+            // at once
+            return new Promise(resolve => {
+                const chunkSize = 10;
+                let results = [];
+                let pos = 0;
+                let running = 0;
+
+                // Process the next spec in the list
+                // and report where all specs have been run
+                async function crawlOneMoreSpec(result) {
+                    if (pos < list.length) {
+                        running += 1;
+                        crawlSpecInChildProcess(list[pos], crawlOptions)
+                            .then(result => {
+                                results.push(result);
+                                running -= 1;
+                                crawlOneMoreSpec();
+                            });
+                        pos += 1;
+                    }
+                    else if (running === 0) {
+                        // No more spec to crawl, and no more running spec
+                        running = -1;
+                        resolve(results);
+                    }
+                }
+
+                // Process the first chunk
+                for (let i = 0; i < chunkSize; i += 1) {
+                    crawlOneMoreSpec();
+                }
+            });
+        });
 }
 
 
@@ -373,7 +470,7 @@ function saveResults(crawlInfo, crawlOptions, data, folder) {
     })
     .then(idlFolder => Promise.all(data.map(spec =>
         new Promise((resolve, reject) => {
-            if (spec.idl.idl) {
+            if (spec.idl && spec.idl.idl) {
                 let idl = `
                     // GENERATED CONTENT - DO NOT EDIT
                     // Content of this file was automatically extracted from the
@@ -423,25 +520,6 @@ function saveResults(crawlInfo, crawlOptions, data, folder) {
 }
 
 
-/**
- * Processes a chunk of the initial list and move on the next chunk afterwards
- *
- * Note that we can probably drop this processing now that memory issues have
- * been solved.
- *
- * @function
- * @private
- */
-function processChunk(crawlInfo, pos, resultsPath, chunkSize, crawlOptions) {
-    let list = crawlInfo.list.slice(pos, pos + chunkSize);
-    return crawlList(list, crawlOptions)
-        .then(data => saveResults(crawlInfo, crawlOptions, data, resultsPath))
-        .then(() => (pos < crawlInfo.list.length - 1) ?
-            processChunk(crawlInfo, pos + chunkSize, resultsPath, chunkSize, crawlOptions) :
-            null);
-}
-
-
 function assembleListOfSpec(filename, nested) {
     let crawlInfo = requireFromWorkingDirectory(filename);
     if (Array.isArray(crawlInfo)) {
@@ -481,9 +559,8 @@ function crawlFile(speclistPath, resultsPath, options) {
         return Promise.reject('Impossible to write to ' + resultsPath + ': ' + err);
     }
 
-    // splitting list to avoid memory exhaustion
-    const chunkSize = 10;
-    return processChunk(crawlInfo, 0, resultsPath, chunkSize, options);
+    return crawlList(crawlInfo.list, options, resultsPath)
+        .then(results => saveResults(crawlInfo, options, results, resultsPath));
 }
 
 
@@ -503,11 +580,22 @@ if (require.main === module) {
     var crawlOptions = {
         publishedVersion: (process.argv[4] === 'tr')
     };
-    crawlFile(speclistPath, resultsPath, crawlOptions)
-        .then(data => {
-            console.log('finished');
-        })
-        .catch(err => {
-            console.error(err);
-        });
+
+    if (speclistPath === '--child') {
+        // Program run as child process of a parent crawl, wait for the spec
+        // info and send the result using message passing
+        process.once('message', spec =>
+            crawlSpec(spec, crawlOptions)
+                .then(result => process.send(result)));
+    }
+    else {
+        // Process the file and crawl specifications it contains
+        crawlFile(speclistPath, resultsPath, crawlOptions)
+            .then(data => {
+                console.log('finished');
+            })
+            .catch(err => {
+                console.error(err);
+            });
+    }
 }

--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -339,6 +339,7 @@ async function crawlList(speclist, crawlOptions, resultsPath) {
     async function crawlSpecInChildProcess(spec) {
         return new Promise(resolve => {
             let resolved = false;
+            let timeout = null;
 
             function reportSuccess(result) {
                 if (resolved) {
@@ -378,7 +379,7 @@ async function crawlList(speclist, crawlOptions, resultsPath) {
                 }
             });
 
-            let timeout = setTimeout(_ => {
+            timeout = setTimeout(_ => {
                 console.warn(spec.url, 'Crawl timeout');
                 reportError(new Error('Crawl took too long'));
                 child.kill();

--- a/src/cli/study-crawl.js
+++ b/src/cli/study-crawl.js
@@ -134,6 +134,8 @@ function studyCrawlResults(results, specsToInclude) {
                 (spec.html && toInclude.html && (spec.html === toInclude.html))))
         .map(spec => {
             spec.idl = spec.idl || {};
+            spec.refs = spec.refs || {};
+            spec.links = spec.links || [];
             var idlDfns = spec.idl.idlNames ?
                 Object.keys(spec.idl.idlNames).filter(name => (name !== '_dependencies') && (name !== '_reallyDependsOnWindow')) : [];
             var idlExtendedDfns = spec.idl.idlExtendedNames ?
@@ -267,12 +269,12 @@ function studyCrawlResults(results, specsToInclude) {
                 // (used to produce the dependencies report)
                 referencedBy: {
                     normative: sortedResults.filter(s =>
-                        s.refs.normative && s.refs.normative.find(r =>
+                        s.refs && s.refs.normative && s.refs.normative.find(r =>
                             canonicalizesTo(r.url, spec.url, useEquivalents) ||
                             canonicalizesTo(r.url, spec.versions, useEquivalents)))
                         .map(filterSpecInfo),
                     informative: sortedResults.filter(s =>
-                        s.refs.informative && s.refs.informative.find(r =>
+                        s.refs && s.refs.informative && s.refs.informative.find(r =>
                             canonicalizesTo(r.url, spec.url, useEquivalents) ||
                             canonicalizesTo(r.url, spec.versions, useEquivalents)))
                         .map(filterSpecInfo)


### PR DESCRIPTION
The crawl of a given spec can be memory and CPU intensive. For instance, the crawl of the HTML spec takes about 1Gb of memory. Running each of them in a separate process guarantees isolation and freeing of resources as soon as possible. From a debugging perspective, it also makes it easier to track a particular spec processing within the task manager.

The crawler spawns 10 child processes at once at most (the number is hardcoded for now, but could be turned into a configuration setting if needed). This mechanism replaces the previous processing in chunks, and improves it as well since new specs get processed as soon as a new child process can be created.

The crawler now monitors and kills child processes that take too long (more than one minute, hardcoded as well for now).

For what it's worth, one consequence of the change is that the `crawl.json` is only written at the end of the crawl (and not filled out progressively after a chunk has been processed).

Performance wise, in the absence of network requests, a crawl used to take about 100s. It now takes 60s.