### PR TITLE
Move staticrange into the W3C set of specs

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -12,7 +12,6 @@
     "https://w3c.github.io/pointerevents/extension.html",
     "https://w3c.github.io/reporting/",
     "https://w3c.github.io/speech-api/",
-    "https://w3c.github.io/staticrange/",
     "https://w3c.github.io/web-nfc/",
     "https://webbluetoothcg.github.io/web-bluetooth/",
     "https://wicg.github.io/animation-worklet/",

--- a/src/specs/specs-w3c-idl.json
+++ b/src/specs/specs-w3c-idl.json
@@ -7,6 +7,7 @@
     "https://www.w3.org/TR/notifications/",
     "https://www.w3.org/TR/progress-events/",
     "https://www.w3.org/TR/selectors-api/",
+    "https://w3c.github.io/staticrange/",
     "https://www.w3.org/TR/webmessaging/",
     "https://www.w3.org/TR/websockets/",
     "https://www.w3.org/TR/webstorage/",


### PR DESCRIPTION
This is to avoid it propagating to idlharness.js tests in wpt:
https://github.com/web-platform-tests/wpt/pull/11816

(The dom.idl in wpt is from https://dom.spec.whatwg.org/, which defines
StaticRange slightly differently, so it would be impossible to pass
tests for both.)