### PR TITLE
Tweak the generated IDL boilerplate further

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -459,9 +459,9 @@ async function saveResults(crawlInfo, crawlOptions, data, folder) {
         if (spec.flags.idl && spec.idl && spec.idl.idl) {
             let idlHeader = `
                 // GENERATED CONTENT - DO NOT EDIT
-                // Content was automatically extracted from the "${spec.title}" spec
-                // by Reffy into reffy-reports (https://github.com/tidoust/reffy-reports)
-                // Spec URL: ${spec.crawled}`;
+                // Content was automatically extracted by Reffy into reffy-reports
+                // (https://github.com/tidoust/reffy-reports)
+                // Source: ${spec.title} (${spec.crawled})`;
             idlHeader = idlHeader.replace(/^\s+/gm, '').trim() + '\n\n';
             let idl = spec.idl.idl
                 .replace(/\s+$/gm, '\n')


### PR DESCRIPTION
Builds on https://github.com/tidoust/reffy/commit/cadc77757bf510519ef1bcb2cea213aae4181731

The 'the "Name of Spec" spec' wording ends up looking odd in the case
of WHATWG specs titles "Foo Standard", for example
'the "Compatibility Standard" spec'.

Fix this by putting the spec name and URL together on one line.