### PR TITLE
Drop the Budget API from the list of specs

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -17,7 +17,6 @@
     "https://wicg.github.io/animation-worklet/",
     "https://wicg.github.io/background-fetch/",
     "https://wicg.github.io/BackgroundSync/spec/",
-    "https://wicg.github.io/budget-api/",
     "https://wicg.github.io/cors-rfc1918/",
     "https://wicg.github.io/CSS-Parser-API/",
     "https://wicg.github.io/entries-api/",


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/pull/12537.