### PR TITLE
Move UISecurity to specs-w3c-idl.json

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -116,7 +116,6 @@
     "https://www.w3.org/TR/SVG2/",
     "https://www.w3.org/TR/touch-events/",
     "https://www.w3.org/TR/uievents/",
-    "https://www.w3.org/TR/UISecurity/",
     "https://www.w3.org/TR/user-timing-2/",
     "https://www.w3.org/TR/vibration/",
     "https://www.w3.org/TR/wai-aria-1.2/",

--- a/src/specs/specs-w3c-idl.json
+++ b/src/specs/specs-w3c-idl.json
@@ -8,6 +8,7 @@
     "https://www.w3.org/TR/progress-events/",
     "https://www.w3.org/TR/selectors-api/",
     "https://w3c.github.io/staticrange/",
+    "https://www.w3.org/TR/UISecurity/",
     "https://www.w3.org/TR/webmessaging/",
     "https://www.w3.org/TR/websockets/",
     "https://www.w3.org/TR/webstorage/",


### PR DESCRIPTION
This is in order to avoid importing it into WPT, see
https://github.com/web-platform-tests/wpt/pull/11795