### PR TITLE
Scrape Service Workers Nightly for WHATWG data set

### DIFF
--- a/src/specs/spec-equivalents.json
+++ b/src/specs/spec-equivalents.json
@@ -71,10 +71,6 @@
     "https://www.w3.org/TR/html-media-capture/": [
         "https://dev.w3.org/2009/dap/camera/"
     ],
-    "https://www.w3.org/TR/service-workers-1/": [
-        "https://w3c.github.io/ServiceWorker/",
-        "https://www.w3.org/TR/service-workers/"
-    ],
     "https://www.w3.org/TR/webvtt1/": [
         "https://dev.w3.org/html5/webvtt/"
     ],

--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -111,7 +111,6 @@
     "https://www.w3.org/TR/secure-contexts/",
     "https://www.w3.org/TR/selection-api/",
     "https://www.w3.org/TR/server-timing/",
-    "https://www.w3.org/TR/service-workers-1/",
     "https://www.w3.org/TR/SRI/",
     "https://www.w3.org/TR/SVG2/",
     "https://www.w3.org/TR/touch-events/",

--- a/src/specs/specs-w3c-idl.json
+++ b/src/specs/specs-w3c-idl.json
@@ -7,6 +7,7 @@
     "https://www.w3.org/TR/notifications/",
     "https://www.w3.org/TR/progress-events/",
     "https://www.w3.org/TR/selectors-api/",
+    "https://www.w3.org/TR/service-workers-1/",
     "https://w3c.github.io/staticrange/",
     "https://www.w3.org/TR/UISecurity/",
     "https://www.w3.org/TR/webmessaging/",

--- a/src/specs/specs-whatwg-idl.json
+++ b/src/specs/specs-whatwg-idl.json
@@ -1,5 +1,6 @@
 [
     "https://dom.spec.whatwg.org/",
     "https://html.spec.whatwg.org/",
-    "https://notifications.spec.whatwg.org/"
+    "https://notifications.spec.whatwg.org/",
+    "https://w3c.github.io/ServiceWorker/"
 ]


### PR DESCRIPTION
This is because v1 is a subset, e.g., FetchEvent:
https://w3c.github.io/ServiceWorker/v1/#fetchevent-interface
https://w3c.github.io/ServiceWorker/#fetchevent-interface

Notices because resultingClientId is missing in wpt/interfaces/.