### PR TITLE
Exclude IDL definitions that have an `exclude` class name

### DIFF
--- a/src/cli/extract-webidl.js
+++ b/src/cli/extract-webidl.js
@@ -93,6 +93,13 @@ function extractBikeshedIdl(doc) {
  * @return {Promise} The promise to get a dump of the IDL definitions
  */
 function extractRespecIdl(doc) {
+    // IDL filter voluntarily similar to that defined in Respec to exclude
+    // IDL defined with an `exclude` class:
+    // https://github.com/w3c/respec/blob/develop/src/core/webidl-index.js#L34
+    // https://github.com/w3c/respec/blob/develop/src/core/utils.js#L100
+    const nonNormativeSelector =
+        '.informative, .note, .issue, .example, .ednote, .practice';
+
     return new Promise(resolve => {
         let idlEl = doc.querySelector('#idl-index pre') ||
             doc.querySelector('#chapter-idl pre');  // Used in SVG 2 draft
@@ -101,15 +108,16 @@ function extractRespecIdl(doc) {
         }
         else {
             let idl = [
-                'pre.idl',
-                'pre > code.idl-code',
-                'pre > code.idl',
-                'div.idl-code > pre',
-                'pre.widl'
+                'pre.idl:not(.exclude)',
+                'pre:not(.exclude) > code.idl-code:not(.exclude)',
+                'pre:not(.exclude) > code.idl:not(.exclude)',
+                'div.idl-code:not(.exclude) > pre:not(.exclude)',
+                'pre.widl:not(.exclude)'
             ]
                 .map(sel => [...doc.querySelectorAll(sel)])
                 .reduce((res, elements) => res.concat(elements), [])
                 .filter((el, idx, self) => self.indexOf(el) === idx)
+                .filter(el => !el.closest(nonNormativeSelector))
                 .map(el => el.textContent.trim())
                 .join('\n\n');
             resolve(idl);

--- a/src/cli/extract-webidl.js
+++ b/src/cli/extract-webidl.js
@@ -108,11 +108,11 @@ function extractRespecIdl(doc) {
         }
         else {
             let idl = [
-                'pre.idl:not(.exclude)',
-                'pre:not(.exclude) > code.idl-code:not(.exclude)',
-                'pre:not(.exclude) > code.idl:not(.exclude)',
-                'div.idl-code:not(.exclude) > pre:not(.exclude)',
-                'pre.widl:not(.exclude)'
+                'pre.idl:not(.exclude):not(.extract)',
+                'pre:not(.exclude):not(.extract) > code.idl-code:not(.exclude):not(.extract)',
+                'pre:not(.exclude):not(.extract) > code.idl:not(.exclude):not(.extract)',
+                'div.idl-code:not(.exclude):not(.extract) > pre:not(.exclude):not(.extract)',
+                'pre.widl:not(.exclude):not(.extract)'
             ]
                 .map(sel => [...doc.querySelectorAll(sel)])
                 .reduce((res, elements) => res.concat(elements), [])


### PR DESCRIPTION
When Reffy extracts individual IDL definition snippets, it now skips over blobs defined with an `exclude` class name, and snippets that are defined in informative sections. The rules are identical to those defined in ReSpec.

Needs to be tested before merging (cannot test for now because I'm on a restricted network).