### PR TITLE
Adapt WebIDL parser to new output of webidl2 parser

### DIFF
--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -144,8 +144,8 @@ function parseIdlAstTree(jsNames, idlNames, idlExtendedNames, externalDependenci
             break;
         case "operation":
             if (def.stringifier) return;
-            parseType(def.idlType, idlNames, externalDependencies, contextName);
-            def.arguments.forEach(a => parseType(a.idlType,  idlNames, externalDependencies, contextName));
+            parseType(def.body.idlType, idlNames, externalDependencies, contextName);
+            def.body.arguments.forEach(a => parseType(a.idlType,  idlNames, externalDependencies, contextName));
             break;
         case "attribute":
         case "field":
@@ -225,8 +225,9 @@ function parseInterfaceOrDictionary(def, jsNames, idlNames, idlExtendedNames, ex
             addDependency(def.inheritance, {}, idlNames._dependencies[def.name]);
         }
         idlNames[def.name] = def;
+        def.extAttrs = def.extAttrs || { items: []};
         var extendedAttributesHasReferences = ea => ["Exposed", "Global", "PrimaryGlobal"].includes(ea.name);
-        def.extAttrs.filter(extendedAttributesHasReferences).forEach(ea => {
+        def.extAttrs.items.filter(extendedAttributesHasReferences).forEach(ea => {
             var contexts = [];
             if (ea.name === "PrimaryGlobal") {
                 // We just found the primary global interface
@@ -256,24 +257,24 @@ function parseInterfaceOrDictionary(def, jsNames, idlNames, idlExtendedNames, ex
                 });
             }
         });
-        if (def.extAttrs.some(ea => ea.name === "Constructor")) {
-            addToJSContext(def.extAttrs, jsNames, def.name, "constructors");
-            def.extAttrs.filter(ea => ea.name === "Constructor").forEach(function(constructor) {
+        if (def.extAttrs.items.some(ea => ea.name === "Constructor")) {
+            addToJSContext(def.extAttrs.items, jsNames, def.name, "constructors");
+            def.extAttrs.items.filter(ea => ea.name === "Constructor").forEach(function(constructor) {
                 if (constructor.arguments) {
                     constructor.arguments.forEach(a => parseType(a.idlType, idlNames, externalDependencies, def.name));
                 }
             });
-        } else if (def.extAttrs.some(ea => ea.name === "NamedConstructor")) {
-            def.extAttrs.filter(ea => ea.name === "NamedConstructor").forEach(function(constructor) {
+        } else if (def.extAttrs.items.some(ea => ea.name === "NamedConstructor")) {
+            def.extAttrs.items.filter(ea => ea.name === "NamedConstructor").forEach(function(constructor) {
                 idlNames[constructor.rhs.value] = constructor;
-                addToJSContext(def.extAttrs, jsNames, def.name, "constructors");
+                addToJSContext(def.extAttrs.items, jsNames, def.name, "constructors");
                 if (constructor.arguments) {
                     constructor.arguments.forEach(a => parseType(a.idlType, idlNames, externalDependencies, def.name));
                 }
             });
         } else if (def.type === "interface") {
-            if (!def.extAttrs.some(ea => ea.name === "NoInterfaceObject")) {
-                addToJSContext(def.extAttrs, jsNames, def.name, "functions");
+            if (!def.extAttrs.items.some(ea => ea.name === "NoInterfaceObject")) {
+                addToJSContext(def.extAttrs.items, jsNames, def.name, "functions");
             }
         }
     }

--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -221,8 +221,8 @@ function parseInterfaceOrDictionary(def, jsNames, idlNames, idlExtendedNames, ex
             if (def.implements === 'window') {
                 idlNames._reallyDependsOnWindow = true;
             }
-            addDependency(def.inheritance, idlNames, externalDependencies);
-            addDependency(def.inheritance, {}, idlNames._dependencies[def.name]);
+            addDependency(def.inheritance.name, idlNames, externalDependencies);
+            addDependency(def.inheritance.name, {}, idlNames._dependencies[def.name]);
         }
         idlNames[def.name] = def;
         def.extAttrs = def.extAttrs || { items: []};

--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -302,7 +302,7 @@ function addToJSContext(eas, jsNames, name, type) {
         if (exposedEa.rhs.type === "identifier") {
             contexts = [exposedEa.rhs.value];
         } else {
-            contexts = exposedEa.rhs.value;
+            contexts = exposedEa.rhs.value.map(x => x.value);
         }
     }
     contexts.forEach(c => { if (!jsNames[type][c]) jsNames[type][c] = []; jsNames[type][c].push(name)});


### PR DESCRIPTION
Currently, crawl.json doesn't include any WebIDL parsed data because the object model coming out the new version WebIDL2.js is incompatible with the existing code.
This change adapts to some of the changes I detected when running parse-webidl.js on the WebRTC spec