### PR TITLE
Use WebIDL includes of mixins as equivalent to partial interfaces in …

### DIFF
--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -162,6 +162,11 @@ function parseIdlAstTree(jsNames, idlNames, idlExtendedNames, externalDependenci
                 idlNames._dependencies[def.target] = [];
             }
             addDependency(def[def.type], {}, idlNames._dependencies[def.target]);
+            if (!idlExtendedNames[def.target]) {
+               idlExtendedNames[def.target] = [];
+            }
+            const mixin = {name: def.target, type: "interface", includes: def.includes};
+            idlExtendedNames[def.target].push(mixin);
             break;
         case "typedef":
             parseType(def.idlType, idlNames, externalDependencies);


### PR DESCRIPTION
…idlExtendedNames

mixin are a shortcut for defining partial interfaces across multiple host, so should be presented similarly to partial interfaces