### PR TITLE
Drop Pointer Events Extensions from spec list

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -18,7 +18,6 @@
     "https://w3c.github.io/media-playback-quality/",
     "https://w3c.github.io/mediasession/",
     "https://w3c.github.io/picture-in-picture/",
-    "https://w3c.github.io/pointerevents/extension.html",
     "https://w3c.github.io/reporting/",
     "https://w3c.github.io/ServiceWorker/",
     "https://w3c.github.io/speech-api/",


### PR DESCRIPTION
Removed in https://github.com/w3c/pointerevents/pull/310.