### PR TITLE
Remove any .idlHeader descendents in extractRespecIdl

### DIFF
--- a/src/cli/extract-webidl.js
+++ b/src/cli/extract-webidl.js
@@ -158,9 +158,13 @@ function extractRespecIdl(doc) {
             .filter(el => !el.closest(nonNormativeSelector))
             .map(el => el.cloneNode(true))
             .map(el => {
+                const header = el.querySelector('.idlHeader');
+                if (header) {
+                    header.remove();
+                }
                 const tests = el.querySelector('details.respec-tests-details');
                 if (tests) {
-                    el.removeChild(tests);
+                    tests.remove();
                 }
                 return el;
             })


### PR DESCRIPTION
Adapting to https://github.com/w3c/respec/pull/2663.

Fixes https://github.com/tidoust/reffy/issues/205.