### PR TITLE
Move MIME Sniffing from blacklist.json to specs-other.json

### DIFF
--- a/src/specs/blacklist.json
+++ b/src/specs/blacklist.json
@@ -29,7 +29,6 @@
   "https://drafts.fxtf.org/fill-stroke/",
   "https://drafts.fxtf.org/matrix/",
   "https://htmlpreview.github.io/?https://raw.github.com/openpeer/ortc/master/ortc.html",
-  "https://mimesniff.spec.whatwg.org/",
   "https://platform.html5.org/history/",
   "https://quirks.spec.whatwg.org/",
   "https://tc39.github.io/ecma262/",

--- a/src/specs/specs-other.json
+++ b/src/specs/specs-other.json
@@ -1,4 +1,5 @@
 [
+  "https://mimesniff.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",
   "https://w3c.github.io/editing/contentEditable.html",
   "https://www.w3.org/TR/mixed-content/",


### PR DESCRIPTION
Its definitions are used a lot in HTML:
https://html.spec.whatwg.org/#mime-type