### PR TITLE
Move Quirks Mode from blacklist.json to specs-css.json

### DIFF
--- a/src/specs/blacklist.json
+++ b/src/specs/blacklist.json
@@ -31,7 +31,6 @@
   "https://htmlpreview.github.io/?https://raw.github.com/openpeer/ortc/master/ortc.html",
   "https://mimesniff.spec.whatwg.org/",
   "https://platform.html5.org/history/",
-  "https://quirks.spec.whatwg.org/",
   "https://tc39.github.io/ecma262/",
   "https://tc39.github.io/ecma402/",
   "https://tc39.github.io/ecmascript_simd/",

--- a/src/specs/specs-css.json
+++ b/src/specs/specs-css.json
@@ -21,6 +21,7 @@
   "https://drafts.csswg.org/scroll-animations-1/",
   "https://drafts.fxtf.org/compositing-2/",
   "https://drafts.fxtf.org/filter-effects-2/",
+  "https://quirks.spec.whatwg.org/",
   "https://www.w3.org/TR/compositing-1/",
   "https://www.w3.org/TR/cssom-view-1/",
   "https://www.w3.org/TR/css-align-3/",


### PR DESCRIPTION
It is referenced from other specs:
https://drafts.csswg.org/css-inline-3/#valdef-line-sizing-legacy
https://drafts.csswg.org/selectors/#informative