### PR TITLE
Update URL of Network Error Logging spec to use non alias shortname

### DIFF
--- a/src/specs/specs-other.json
+++ b/src/specs/specs-other.json
@@ -9,7 +9,7 @@
   "https://wicg.github.io/web-share-target/",
   "https://www.w3.org/TR/clear-site-data/",
   "https://www.w3.org/TR/mixed-content/",
-  "https://www.w3.org/TR/network-error-logging/",
+  "https://www.w3.org/TR/network-error-logging-1/",
   "https://www.w3.org/TR/payment-method-id/",
   "https://www.w3.org/TR/payment-method-manifest/",
   "https://www.w3.org/TR/preload/",


### PR DESCRIPTION
The W3C API still does not recognize aliases of shortname for the time being and thus returns an error when the crawler tries to get some info about the spec.

The update makes the crawler use the URL with the shortname `network-error-logging-1` instead of the one with `network-error-logging`.

@foolip FYI. I had missed that one...