### PR TITLE
Fix bug that made Reffy crawl the Compatibility standard 4 times

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -393,22 +393,23 @@ async function crawlList(speclist, crawlOptions, resultsPath) {
                 // when all specs have been crawled
                 async function crawlOneMoreSpec() {
                     if (pos < list.length) {
+                        let spec = list[pos];
+                        pos += 1;
                         running += 1;
                         let result;
                         if (crawlOptions.debug) {
-                            console.log(`Crawling ${list[pos].url}...`);
-                            result = await crawlSpec(list[pos], crawlOptions);
-                            console.log(`Crawling ${list[pos].url}... done`);
+                            console.log(`Crawling ${spec.url}...`);
+                            result = await crawlSpec(spec, crawlOptions);
+                            console.log(`Crawling ${spec.url}... done`);
                         }
                         else {
-                            result = await crawlSpecInChildProcess(list[pos], crawlOptions);
+                            result = await crawlSpecInChildProcess(spec, crawlOptions);
                         }
                         if (!result.crawled) {
                             result.crawled = result.latest;
                         }
                         results.push(result);
                         running -= 1;
-                        pos += 1;
                         crawlOneMoreSpec();
                     }
                     else if (running === 0) {


### PR DESCRIPTION
The "current position" counter was only incremented *after* a spec had been processed. This meant that the same spec could be processed more than once. The first spec in the list - the Compatibility Standard in practice - was crawled 4 times in particular (4 being the number of processes that run in parallel).

Fixes #233.