### PR TITLE
Add video-raf spec to specs-idl.json

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -50,6 +50,7 @@
     "https://wicg.github.io/permissions-revoke/",
     "https://wicg.github.io/shape-detection-api/",
     "https://wicg.github.io/speech-api/",
+    "https://wicg.github.io/video-raf/",
     "https://wicg.github.io/visual-viewport/",
     "https://wicg.github.io/web-locks/",
     "https://wicg.github.io/webusb/",


### PR DESCRIPTION
Video-raf is a proposal to add an HTMLVideoElement.requestAnimationFrame() method.