### PR TITLE
Track and report final redirected URL

### DIFF
--- a/src/cli/generate-report.js
+++ b/src/cli/generate-report.js
@@ -70,19 +70,12 @@ function writeCrawlInfo(spec, withHeader, w) {
     }
     w();
 
-    let crawledVersion = 'Initial URL';
     let crawledUrl = spec.crawled || spec.latest;
-    if ((crawledUrl === spec.datedUrl) || (crawledUrl === spec.latest)) {
-        crawledVersion = 'Latest published version';
+    w('- Initial URL: [' + spec.url + '](' + spec.url + ')');
+    w('- Crawled URL: [' + crawledUrl + '](' + crawledUrl + ')');
+    if (spec.date) {
+        w('- Crawled version: ' + spec.date);
     }
-    else if (crawledUrl === spec.edDraft) {
-        crawledVersion = 'Editor\'s Draft';
-    }
-    else if (crawledUrl.indexOf('spec.whatwg.org') !== -1) {
-        crawledVersion = 'Living Standard';
-    }
-    w('- Crawled version: [' + crawledVersion + '](' + crawledUrl + ')' +
-        (spec.date ? ' (' + spec.date + ')' : ''));
     if (spec.edDraft) {
         w('- Editor\'s Draft: [' + spec.edDraft + '](' + spec.edDraft + ')');
     }
@@ -909,19 +902,10 @@ function generateDiffReport(study, refStudy, options) {
 
         w('## ' + spec.title);
         w();
-        w('- URL: [' + spec.url + '](' + spec.url + ')');
-        let crawledVersion = 'Initial URL';
+
         let crawledUrl = spec.crawled || spec.latest;
-        if ((crawledUrl === spec.datedUrl) || (crawledUrl === spec.latest)) {
-            crawledVersion = 'Latest published version';
-        }
-        else if (crawledUrl === spec.edDraft) {
-            crawledVersion = 'Editor\'s Draft';
-        }
-        else if (crawledUrl.indexOf('spec.whatwg.org') !== -1) {
-            crawledVersion = 'Living Standard';
-        }
-        w('- Crawled version: [' + crawledVersion + '](' + crawledUrl + ')');
+        w('- Initial URL: [' + spec.url + '](' + spec.url + ')');
+        w('- Crawled URL: [' + crawledUrl + '](' + crawledUrl + ')');
         if (spec.edDraft && (spec.edDraft !== crawledUrl)) {
             w('- Editor\'s Draft: [' + spec.edDraft + '](' + spec.edDraft + ')');
         }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -99,7 +99,7 @@ async function loadSpecificationFromHtml(spec, counter) {
             let singlePage = URL.resolve(doc.baseURI, link.getAttribute('href'));
             if ((singlePage === url) || (singlePage === responseUrl)) {
                 // We're already looking at the single page version
-                return window;
+                return { url: responseUrl, window };
             }
             else {
                 return loadSpecificationFromUrl(singlePage, counter + 1);
@@ -121,7 +121,7 @@ async function loadSpecificationFromHtml(spec, counter) {
             pages.map(page => loadSpecificationFromUrl(page)));
         subWindows.map(subWindow => {
             const section = doc.createElement('section');
-            [...subWindow.document.body.children].forEach(
+            [...subWindow.window.document.body.children].forEach(
                 child => section.appendChild(child));
             doc.body.appendChild(section);
         });
@@ -145,7 +145,7 @@ async function loadSpecificationFromHtml(spec, counter) {
         });
     }
 
-    return window;
+    return { url: responseUrl, window };
 }
 
 
@@ -197,7 +197,7 @@ function loadSpecification(spec) {
 
 function urlOrDom(input) {
     if (typeof input === "string") {
-        return loadSpecification(input);
+        return loadSpecification(input).then(loaded => loaded.window);
     } else {
         return Promise.resolve(input);
     }


### PR DESCRIPTION
In the crawl results, the `crawled` URL was the URL initially fetched by the crawler, and not the final URL after possible redirects. With this update, the URL that appears in `crawled` becomes the final redirected URL.

Note the `edDraft` URL remains untouched and is the URL of the Editor's Draft as advertised in the published version of the spec.

See discussion in #220.