### PR TITLE
Drop hardcoded rules for ED and multi-page specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,6 @@ Optional parameters:
 * `cacheRefresh`: set this flag to `never` to tell the crawler to use the cache entry for a URL directly, instead of sending a conditional HTTP request to check whether the entry is still valid. This parameter is typically useful when developing Reffy's code to work offline.
 * `resetCache`: set this flag to `true` to tell the crawler to reset the contents of the local cache when it starts.
 
-### Hardcoded rules
-
-Some rules or exceptions to the rule are hardcoded. In particular:
-
-* The URL of some of the Editor's Drafts returned by the W3C API can be invalid, or a document that when loaded redirects to another. The list is hardcoded in the `completeWithInfoFromW3CApi`method in `src/cli/crawl-specs.js`. The crawler loads the latest published version for these specs.
-* The heuristics used to find the "single page" link are defined in the `processSpecification` function in `util.js`. They may need to be extended to support other cases.
-* For each spec, the crawler reports a list of URLs which may be considered as equivalent for the purpose of referencing. This list typically includes the initial shortname URL for W3C specs, the dated URL of the latest published version of the spec, and the URL of the Editor's Draft. For a couple of specs, it also includes links to previous or alternate "versions" of the spec. For instance, the versions of the HTML5.1 spec include the HTML5 W3C Recommendation and the WHATWG HTML Living Standard. The study tool uses that information when it checks the list of references to find missing ones. Ideally, the W3C API would return up-to-date information such as "supercedes" to clarify the relationship between versions of the same spec. The mapping is hardcoded in `addKnownVersions` in `src/lib/util.js`.
 
 ## Contributing
 

--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -139,14 +139,9 @@ async function createInitialSpecDescriptions(list) {
  */
 async function crawlSpec(spec, crawlOptions) {
     spec.title = spec.title || (spec.shortname ? spec.shortname : spec.url);
-    var bogusEditorDraft = ['webmessaging', 'eventsource', 'webstorage', 'progress-events'];
-    var unparseableEditorDraft = [];
-    spec.crawled = ((
-            crawlOptions.publishedVersion ||
-            bogusEditorDraft.includes(spec.shortname) ||
-            unparseableEditorDraft.includes(spec.shortname)) ?
+    spec.crawled = crawlOptions.publishedVersion ?
         spec.datedUrl || spec.latest || spec.url :
-        spec.edDraft || spec.url);
+        spec.edDraft || spec.url;
     spec.date = "";
     spec.links = [];
     spec.refs = {};
@@ -165,7 +160,7 @@ async function crawlSpec(spec, crawlOptions) {
                 dfns: window.reffy.extractDefinitions(),
                 refs: window.reffy.extractReferences(),
                 idl: window.reffy.extractWebIdl(),
-                css: window.reffy.extractCSS(),
+                css: window.reffy.extractCSS()
             };
         });
 


### PR DESCRIPTION
We no longer have issues with bogus Editor's Drafts.

Also, it turns out that the multi-page logic can be simplified. New code does not require any hardcoded rule (same selector for all specs and no need to identify multi-page specs to start with).