### PR TITLE
Update video-raf pointer to video-rvfc

### DIFF
--- a/src/specs/specs-idl.json
+++ b/src/specs/specs-idl.json
@@ -43,7 +43,7 @@
     "https://wicg.github.io/permissions-revoke/",
     "https://wicg.github.io/shape-detection-api/",
     "https://wicg.github.io/speech-api/",
-    "https://wicg.github.io/video-raf/",
+    "https://wicg.github.io/video-rvfc/",
     "https://wicg.github.io/visual-viewport/",
     "https://wicg.github.io/web-locks/",
     "https://wicg.github.io/web-transport/",


### PR DESCRIPTION
The video.requestAnimationFrame API was renamed to the video.requestVideoFrameCallback API.

This updates the video-raf entry to point towards the new repo and to crawl the spec under the new name.