### PR TITLE
Handle SVG-specific conventions in definitions

### DIFF
--- a/builds/browser.js
+++ b/builds/browser.js
@@ -2709,9 +2709,13 @@ for more information.`;
       'h5[id][data-dfn-type]:not([data-lt=""])',
       'h6[id][data-dfn-type]:not([data-lt=""])'
     ].join(',');
-
-    if (spec === "html") {
+    switch (spec) {
+    case "html":
       preProcessHTML();
+      break;
+    case "SVG2":
+      preProcessSVG2();
+      break;
     }
 
     return [...document.querySelectorAll(definitionsSelector)]
@@ -3092,6 +3096,84 @@ for more information.`;
         }
 
       });
+  }
+
+  function preProcessSVG2() {
+    const idl = extractWebIdl();
+    const idlTree = parse(idl);
+    const idlInterfaces = idlTree.filter(item => item.type === "interface" || item.type === "interface mixin");
+
+    // the only element definition not properly marked up in the SVG spec
+    const linkHeading = document.getElementById("LinkElement");
+    if (linkHeading && !linkHeading.dataset.dfnType) {
+      linkHeading.dataset.dfnType = "element";
+      linkHeading.dataset.lt = "link";
+    }
+
+    [...document.querySelectorAll(".attrdef dfn[id]:not([data-dfn-type]):not([data-skip])")]
+      .forEach(el => {
+        el.dataset.dfnType = "element-attr";
+        const attrDesc = document.querySelector('[data-reffy-page$="attindex.html"] th span.attr-name a[href$="#' + el.id + '"]');
+        if (attrDesc) {
+            el.dataset.dfnFor = attrDesc.closest('tr').querySelector('td').textContent;
+        } else {
+          console.error("Could not find description for " + el.textContent);
+        }
+      });
+    [...document.querySelectorAll("dt[id] > .adef, dt[id] > .property")].forEach(el => {
+      const dt = el.parentNode;
+      const newdt = document.createElement("dt");
+      const dfn = document.createElement("dfn");
+      dfn.id = dt.id;
+      dfn.dataset.dfnType = el.classList.contains("adef") ? "element-attr" : "property";
+      const indexPage = el.classList.contains("adef") ? "attindex.html" : "propidx.html";
+      const attrDesc = document.querySelector('[data-reffy-page$="' + indexPage + '"] th a[href$="#' + dfn.id + '"]');
+      if (attrDesc) {
+        // TODO: this doesn't deal with grouping of elements, e.g. "text content elements"
+        dfn.dataset.dfnFor = [...attrDesc.closest('tr').querySelectorAll('span.element-name a')].map (n => n.textContent).join(',');
+      } else {
+        console.error("Could not find description for " + el.textContent + "/" + dfn.id);
+      }
+      dfn.textContent = el.textContent;
+      newdt.appendChild(dfn);
+      dt.replaceWith(newdt);
+    });
+    [...document.querySelectorAll('b[id^="__svg__"]')].forEach(el => {
+      const [,, containername, membername] = el.id.split('__');
+      if (containername && membername) {
+        let container = idlTree.find(i => i.name === containername);
+        if (container) {
+          let member = container.members.find(m => m.name === membername);
+          if (member) {
+            const dfn = document.createElement("dfn");
+            dfn.id = el.id;
+            dfn.textContent = el.textContent;
+            dfn.dataset.dfnFor = containername;
+            dfn.dataset.dfnType = member.type === "operation" ? "method" : member.type;
+            el.replaceWith(dfn);
+          }
+        }
+      }
+    });
+    [...document.querySelectorAll('h3[id^="Interface"]:not([data-dfn-type])')].forEach(el => {
+      const name = el.id.slice("Interface".length);
+      if (idlTree.find(i => i.name === name && i.type === "interface")) {
+        el.dataset.dfnType = "interface";
+        el.dataset.lt = name;
+      }
+    });
+    [...document.querySelectorAll('b[id]:not([data-dfn-type])')].forEach(el => {
+      const name = el.textContent;
+      const idlItem = idlTree.find(i => i.name === name) ;
+      if (idlItem) {
+        const dfn = document.createElement("dfn");
+        dfn.id = el.id;
+        dfn.dataset.dfnType = idlItem.type;
+        dfn.textContent = el.textContent;
+        el.replaceWith(dfn);
+      }
+    });
+
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "ed-html": "node reffy.js run ed html",
     "ed-diff": "node reffy.js run ed diff",
     "ed-diffnew": "node reffy.js run ed diffnew",
-    "test": "jasmine && mocha --recursive tests/"
+    "test": "npm run build && jasmine && mocha --recursive tests/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "ed-html": "node reffy.js run ed html",
     "ed-diff": "node reffy.js run ed diff",
     "ed-diffnew": "node reffy.js run ed diffnew",
-    "test": "npm run build && jasmine && mocha --recursive tests/"
+    "test": "jasmine && mocha --recursive tests/"
   }
 }

--- a/src/browserlib/extract-dfns.js
+++ b/src/browserlib/extract-dfns.js
@@ -95,9 +95,13 @@ export default function (spec) {
   ].join(',');
 
   let extraDefinitions = [];
-
-  if (spec === "html") {
+  switch (spec) {
+  case "html":
     preProcessHTML();
+    break;
+  case "SVG2":
+    preProcessSVG2();
+    break;
   }
 
   return [...document.querySelectorAll(definitionsSelector)]
@@ -479,4 +483,82 @@ function preProcessHTML() {
       }
 
     });
+}
+
+function preProcessSVG2() {
+  const idl = extractWebIdl();
+  const idlTree = parse(idl);
+  const idlInterfaces = idlTree.filter(item => item.type === "interface" || item.type === "interface mixin");
+
+  // the only element definition not properly marked up in the SVG spec
+  const linkHeading = document.getElementById("LinkElement");
+  if (linkHeading && !linkHeading.dataset.dfnType) {
+    linkHeading.dataset.dfnType = "element";
+    linkHeading.dataset.lt = "link";
+  }
+
+  [...document.querySelectorAll(".attrdef dfn[id]:not([data-dfn-type]):not([data-skip])")]
+    .forEach(el => {
+      el.dataset.dfnType = "element-attr";
+      const attrDesc = document.querySelector('[data-reffy-page$="attindex.html"] th span.attr-name a[href$="#' + el.id + '"]');
+      if (attrDesc) {
+          el.dataset.dfnFor = attrDesc.closest('tr').querySelector('td').textContent;
+      } else {
+        console.error("Could not find description for " + el.textContent);
+      }
+    });
+  [...document.querySelectorAll("dt[id] > .adef, dt[id] > .property")].forEach(el => {
+    const dt = el.parentNode;
+    const newdt = document.createElement("dt");
+    const dfn = document.createElement("dfn");
+    dfn.id = dt.id;
+    dfn.dataset.dfnType = el.classList.contains("adef") ? "element-attr" : "property";
+    const indexPage = el.classList.contains("adef") ? "attindex.html" : "propidx.html";
+    const attrDesc = document.querySelector('[data-reffy-page$="' + indexPage + '"] th a[href$="#' + dfn.id + '"]');
+    if (attrDesc) {
+      // TODO: this doesn't deal with grouping of elements, e.g. "text content elements"
+      dfn.dataset.dfnFor = [...attrDesc.closest('tr').querySelectorAll('span.element-name a')].map (n => n.textContent).join(',');
+    } else {
+      console.error("Could not find description for " + el.textContent + "/" + dfn.id);
+    }
+    dfn.textContent = el.textContent;
+    newdt.appendChild(dfn);
+    dt.replaceWith(newdt);
+  });
+  [...document.querySelectorAll('b[id^="__svg__"]')].forEach(el => {
+    const [,, containername, membername] = el.id.split('__');
+    if (containername && membername) {
+      let container = idlTree.find(i => i.name === containername);
+      if (container) {
+        let member = container.members.find(m => m.name === membername);
+        if (member) {
+          const dfn = document.createElement("dfn");
+          dfn.id = el.id;
+          dfn.textContent = el.textContent;
+          dfn.dataset.dfnFor = containername;
+          dfn.dataset.dfnType = member.type === "operation" ? "method" : member.type;
+          el.replaceWith(dfn);
+        }
+      }
+    }
+  });
+  [...document.querySelectorAll('h3[id^="Interface"]:not([data-dfn-type])')].forEach(el => {
+    const name = el.id.slice("Interface".length);
+    if (idlTree.find(i => i.name === name && i.type === "interface")) {
+      el.dataset.dfnType = "interface";
+      el.dataset.lt = name;
+    }
+  });
+  [...document.querySelectorAll('b[id]:not([data-dfn-type])')].forEach(el => {
+    const name = el.textContent;
+    const idlItem = idlTree.find(i => i.name === name) ;
+    if (idlItem) {
+      const dfn = document.createElement("dfn");
+      dfn.id = el.id;
+      dfn.dataset.dfnType = idlItem.type;
+      dfn.textContent = el.textContent;
+      el.replaceWith(dfn);
+    }
+  });
+
 }

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -37,6 +37,44 @@ partial interface mixin NavigatorID {
 enum CanPlayTypeResult { ""};
 </code></pre>`;
 
+const baseSVG2 = `
+<!-- we use the IDL declarations to find the type of attribute vs methods -->
+<pre class=idl>
+interface SVGNameList {
+
+  readonly attribute unsigned long length;
+  readonly attribute unsigned long numberOfItems;
+
+  void clear();
+  Type initialize(Type newItem);
+};
+[Exposed=Window]
+interface SVGAnimatedLengthList {
+};
+</pre>
+<!-- we use the attindex page to associate attributes to elements -->
+<div data-reffy-page='https://example.org/attindex.html'>
+<table>
+<tr><th><span class="attr-name"><a href="struct.html#RequiredExtensionsAttribute"><span>requiredExtensions</span></a></span></th><td><span class="element-name"><a href="linking.html#AElement"><span>a</span></a></span>, <span class="element-name"><a href="https://svgwg.org/specs/animations/#AnimateElement"><span>animate</span></a></span>, <span class="element-name"><a href="https://svgwg.org/specs/animations/#AnimateMotionElement"><span>animateMotion</span></a></span>, <span class="element-name"><a href="https://svgwg.org/specs/animations/#AnimateTransformElement"><span>animateTransform</span></a></span>, <span class="element-name"><a href="embedded.html#HTMLElements"><span>audio</span></a></span>, <span class="element-name"><a href="embedded.html#HTMLElements"><span>canvas</span></a></span>, <span class="element-name"><a href="shapes.html#CircleElement"><span>circle</span></a></span>, <span class="element-name"><a href="https://drafts.fxtf.org/css-masking-1/#ClipPathElement"><span>clipPath</span></a></span>, <span class="element-name"><a href="https://svgwg.org/specs/animations/#DiscardElement"><span>discard</span></a></span>, <span class="element-name"><a href="shapes.html#EllipseElement"><span>ellipse</span></a></span>, <span class="element-name"><a href="embedded.html#ForeignObjectElement"><span>foreignObject</span></a></span>, <span class="element-name"><a href="struct.html#GElement"><span>g</span></a></span>, <span class="element-name"><a href="embedded.html#HTMLElements"><span>iframe</span></a></span>, <span class="element-name"><a href="embedded.html#ImageElement"><span>image</span></a></span>, <span class="element-name"><a href="shapes.html#LineElement"><span>line</span></a></span>, <span class="element-name"><a href="https://drafts.fxtf.org/css-masking-1/#MaskElement"><span>mask</span></a></span>, <span class="element-name"><a href="paths.html#PathElement"><span>path</span></a></span>, <span class="element-name"><a href="shapes.html#PolygonElement"><span>polygon</span></a></span>, <span class="element-name"><a href="shapes.html#PolylineElement"><span>polyline</span></a></span>, <span class="element-name"><a href="shapes.html#RectElement"><span>rect</span></a></span>, <span class="element-name"><a href="https://svgwg.org/specs/animations/#SetElement"><span>set</span></a></span>, <span class="element-name"><a href="struct.html#SVGElement"><span>svg</span></a></span>, <span class="element-name"><a href="struct.html#SwitchElement"><span>switch</span></a></span>, <span class="element-name"><a href="text.html#TextElement"><span>text</span></a></span>, <span class="element-name"><a href="text.html#TextPathElement"><span>textPath</span></a></span>, <span class="element-name"><a href="text.html#TextElement"><span>tspan</span></a></span>, <span class="element-name"><a href="struct.html#UnknownElement"><span>unknown</span></a></span>, <span class="element-name"><a href="struct.html#UseElement"><span>use</span></a></span>, <span class="element-name"><a href="embedded.html#HTMLElements"><span>video</span></a></span></td><td></td></tr>
+<tr><th><span class="attr-name"><a href="pservers.html#PatternElementPatternUnitsAttribute"><span>patternUnits</span></a></span></th><td><span class="element-name"><a href="pservers.html#PatternElement"><span>pattern</span></a></span></td><td>✓</td></tr>
+</table></div>
+<!-- We use the property index to associate properties with elements -->
+<div data-reffy-page='https://example.org/propidx.html'>
+<table>
+<tr>
+          <th><a class="property" href="pservers.html#StopOpacityProperty">stop-opacity</a></th>
+          <td>&lt;‘<a class="property" href="render.html#ObjectAndGroupOpacityProperties">opacity</a>’&gt;</td>
+          <td>1</td>
+          <td><span class="element-name">‘<a href="pservers.html#StopElement"><span>stop</span></a>’</span> elements</td>
+          <td>no</td>
+          <td>N/A</td>
+          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
+          <td>by computed value</td>
+          <td>the specified value converted to a number, clamped to the range [0,1]</td>
+        </tr>
+</table></div>
+`;
+
 const baseDfn = {
     id: 'foo',
     linkingText: [ 'Foo' ],
@@ -321,13 +359,159 @@ const tests = [
       href: "https://example.org/indices.html#text/xml"
     }],
     spec: "html"
+  },
+  {
+    "title": "extracts attribute definition from the SVG2 spec",
+    html: `<table class="attrdef def"><tr>
+        <td><dfn id="RequiredExtensionsAttribute">requiredExtensions</dfn></td>
+        <td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens">set of space-separated tokens</a> <span class="syntax">[HTML]</span></td>
+        <td>(none)</td>
+        <td>no</td>
+      </tr></table>`,
+    changesToBaseDfn: [{
+      id: "RequiredExtensionsAttribute",
+      linkingText: ["requiredExtensions"],
+      type: "element-attr",
+      for: ["a",
+            "animate",
+            "animateMotion",
+            "animateTransform",
+            "audio",
+            "canvas",
+            "circle",
+            "clipPath",
+            "discard",
+            "ellipse",
+            "foreignObject",
+            "g",
+            "iframe",
+            "image",
+            "line",
+            "mask",
+            "path",
+            "polygon",
+            "polyline",
+            "rect",
+            "set",
+            "svg",
+            "switch",
+            "text",
+            "textPath",
+            "tspan",
+            "unknown",
+            "use",
+            "video"
+           ],
+      "access": "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifes the link element definition in SVG2 spec",
+    html: `<h2 id="LinkElement" class="heading">6.3. External style sheets: the effect of the HTML <span class="element-name">‘link’</span> element<a class="self-link" href="#LinkElement"></a></h2>`,
+    changesToBaseDfn: [{
+      id: "LinkElement",
+      linkingText: ["link"],
+      type: "element",
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifes attributes defined with class adef in SVG2 spec",
+    html: `<dt id="PatternElementPatternUnitsAttribute"><span class="adef">patternUnits</span></dt>`,
+    changesToBaseDfn: [{
+      id: "PatternElementPatternUnitsAttribute",
+      linkingText: ["patternUnits"],
+      type: "element-attr",
+      "for": ["pattern"],
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifes properties defined with class propdef in SVG2 spec",
+    html: `<dt id="StopOpacityProperty">‘<span class="propdef-title property">stop-opacity</span>’</dt>`,
+    changesToBaseDfn: [{
+      id: "StopOpacityProperty",
+      linkingText: ["stop-opacity"],
+      type: "property",
+      "for": ["stop"],
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifes IDL attributes and methods defined in SVG2 spec",
+    html: `<p>The <b id="__svg__SVGNameList__length">length</b> IDL attribute
+represents the length of the list, and on getting simply return
+the length of the list.</p>
+<p>The <b id="__svg__SVGNameList__initialize">initialize</b> method
+is used to clear the list and add a single, specified value to it.
+When initialize(<var>newItem</var>) is called, the following steps are run:</p>`,
+    changesToBaseDfn: [{
+      id: "__svg__SVGNameList__length",
+      linkingText: ["length"],
+      type: "attribute",
+      "for": ["SVGNameList"],
+      access: "public"
+    },
+                       {
+      id: "__svg__SVGNameList__initialize",
+      linkingText: ["initialize"],
+      type: "method",
+      "for": ["SVGNameList"],
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identified IDL interfaces in headings of the SVG2 spec",
+    html: `<h3 id="InterfaceSVGAnimatedLengthList" class="heading">4.6.10. Interface SVGAnimatedLengthList<a class="self-link" href="#InterfaceSVGAnimatedLengthList"></a></h3>`,
+    changesToBaseDfn: [{
+      id: "InterfaceSVGAnimatedLengthList",
+      linkingText: ["SVGAnimatedLengthList"],
+      type: "interface",
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifies a dictionary definition in an IDL fragment of the SVG2 spec",
+    html: `<pre class="idl">dictionary <b id="SVGBoundingBoxOptions">SVGBoundingBoxOptions</b> {
+  boolean fill = true;
+  boolean stroke = false;
+  boolean markers = false;
+  boolean clipped = false;
+};
+</pre>
+`,
+    changesToBaseDfn: [{
+      id: "SVGBoundingBoxOptions",
+      linkingText: ["SVGBoundingBoxOptions"],
+      type: "dictionary",
+      access: "public"
+    }],
+    spec :"SVG2",
   }
-
 ];
 
 async function assertExtractedDefinition(browser, html, dfns, spec) {
   const page = await browser.newPage();
-  page.setContent((spec === "html" ? baseHtml : "") + html + "<script>let spec = '" + spec + "';</script>");
+  let pageContent = "";
+  switch(spec) {
+  case "html":
+    pageContent = baseHtml;
+    break;
+  case "SVG2":
+    pageContent = baseSVG2;
+    break;
+  };
+  pageContent += html + "<script>let spec = '" + spec + "';</script>"
+  page
+    .on('console', message =>
+        console.error(`${message.type().substr(0, 3).toUpperCase()} ${message.text()}`));
+  page.setContent(pageContent);
   await page.addScriptTag({
     path: path.resolve(__dirname, '../builds/browser.js')
   });
@@ -337,7 +521,7 @@ async function assertExtractedDefinition(browser, html, dfns, spec) {
   });
   await page.close();
 
-  assert.deepEqual(dfns.map(d => Object.assign({}, baseDfn, {href: "about:blank#" + (d.id || baseDfn.id)}, d)), extractedDfns);
+  assert.deepEqual(extractedDfns, dfns.map(d => Object.assign({}, baseDfn, {href: "about:blank#" + (d.id || baseDfn.id)}, d)));
 }
 
 

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -407,7 +407,7 @@ const tests = [
     spec: "SVG2"
   },
   {
-    title: "identifes the link element definition in SVG2 spec",
+    title: "identifies the link element definition in SVG2 spec",
     html: `<h2 id="LinkElement" class="heading">6.3. External style sheets: the effect of the HTML <span class="element-name">‘link’</span> element<a class="self-link" href="#LinkElement"></a></h2>`,
     changesToBaseDfn: [{
       id: "LinkElement",
@@ -418,31 +418,31 @@ const tests = [
     spec: "SVG2"
   },
   {
-    title: "identifes attributes defined with class adef in SVG2 spec",
+    title: "identifies attributes defined with class adef in SVG2 spec",
     html: `<dt id="PatternElementPatternUnitsAttribute"><span class="adef">patternUnits</span></dt>`,
     changesToBaseDfn: [{
       id: "PatternElementPatternUnitsAttribute",
       linkingText: ["patternUnits"],
       type: "element-attr",
-      "for": ["pattern"],
+      for: ["pattern"],
       access: "public"
     }],
     spec: "SVG2"
   },
   {
-    title: "identifes properties defined with class propdef in SVG2 spec",
+    title: "identifies properties defined with class propdef in SVG2 spec",
     html: `<dt id="StopOpacityProperty">‘<span class="propdef-title property">stop-opacity</span>’</dt>`,
     changesToBaseDfn: [{
       id: "StopOpacityProperty",
       linkingText: ["stop-opacity"],
       type: "property",
-      "for": ["stop"],
+      for: ["stop"],
       access: "public"
     }],
     spec: "SVG2"
   },
   {
-    title: "identifes IDL attributes and methods defined in SVG2 spec",
+    title: "identifies IDL attributes and methods defined in SVG2 spec",
     html: `<p>The <b id="__svg__SVGNameList__length">length</b> IDL attribute
 represents the length of the list, and on getting simply return
 the length of the list.</p>
@@ -453,20 +453,20 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       id: "__svg__SVGNameList__length",
       linkingText: ["length"],
       type: "attribute",
-      "for": ["SVGNameList"],
+      for: ["SVGNameList"],
       access: "public"
     },
                        {
       id: "__svg__SVGNameList__initialize",
       linkingText: ["initialize"],
       type: "method",
-      "for": ["SVGNameList"],
+      for: ["SVGNameList"],
       access: "public"
     }],
     spec: "SVG2"
   },
   {
-    title: "identified IDL interfaces in headings of the SVG2 spec",
+    title: "identifies IDL interfaces in headings of the SVG2 spec",
     html: `<h3 id="InterfaceSVGAnimatedLengthList" class="heading">4.6.10. Interface SVGAnimatedLengthList<a class="self-link" href="#InterfaceSVGAnimatedLengthList"></a></h3>`,
     changesToBaseDfn: [{
       id: "InterfaceSVGAnimatedLengthList",


### PR DESCRIPTION
This brings the output of Reffy to parity with shepherd on the SVG2 spec
close #334
