### PR TITLE
Pin dependencies to specific versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,22 +33,22 @@
     "study-crawl": "./src/cli/study-crawl.js"
   },
   "dependencies": {
-    "abortcontroller-polyfill": "^1.4.0",
-    "browser-specs": "^1.10.0",
-    "commander": "^6.0.0",
-    "fetch-filecache-for-crawling": "^4.0.2",
-    "node-pandoc": "^0.3.0",
-    "puppeteer": "^5.0.0",
-    "webidl2": "^23.13.0"
+    "abortcontroller-polyfill": "1.5.0",
+    "browser-specs": "1.13.0",
+    "commander": "6.0.0",
+    "fetch-filecache-for-crawling": "4.0.2",
+    "node-pandoc": "0.3.0",
+    "puppeteer": "5.2.1",
+    "webidl2": "23.13.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "jasmine": "^3.4.0",
-    "mocha": "^8.0.1",
-    "nock": "^13.0.2",
-    "respec": "^25.11.0",
-    "respec-hljs": "^2.1.1",
-    "rollup": "^2.0.3"
+    "chai": "4.2.0",
+    "jasmine": "3.6.1",
+    "mocha": "8.1.1",
+    "nock": "13.0.4",
+    "respec": "25.14.0",
+    "respec-hljs": "2.1.1",
+    "rollup": "2.17.0"
   },
   "scripts": {
     "build": "rollup --config src/browserlib/rollup.config.js",


### PR DESCRIPTION
Versions of dependencies in package.json were prefixed with "^". Dependabot correctly updated minor versions in package-lock.json but there was no easy way to tell which specific version of a dependency was being used simply by looking at package.json. Hence pull requests such as #379 that are actually not fully needed since latest version of WebIDL2 parser was already being used.

This update drops the "^" prefixes, and updates the versions accordingly to match those in package-lock.json. In turn, this should mean that dependabot will now update package.json each time an update gets made.