### PR TITLE
Update URL in IDL preamble following repo transfer

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -284,8 +284,8 @@ async function saveResults(crawlOptions, data, folder) {
     async function saveIdl(spec) {
         let idlHeader = `
             // GENERATED CONTENT - DO NOT EDIT
-            // Content was automatically extracted by Reffy into reffy-reports
-            // (https://github.com/tidoust/reffy-reports)
+            // Content was automatically extracted by Reffy into webref
+            // (https://github.com/w3c/webref)
             // Source: ${spec.title} (${spec.crawled})`;
         idlHeader = idlHeader.replace(/^\s+/gm, '').trim() + '\n\n';
         let idl = spec.idl.idl


### PR DESCRIPTION
URL used to point at tidoust/reffy-reports. The update makes it point at the new w3c/webref repository.

Update will change all generated IDL files at once. Merge should to be done in sync with @foolip to avoid polluting Web Platform Tests with hundreds of editorial PRs...