### PR TITLE
Normalize spaces in headings titles

### DIFF
--- a/builds/browser.js
+++ b/builds/browser.js
@@ -3944,7 +3944,7 @@ for more information.`;
 
         mappingTable[node.id] = {
           id,
-          title: trimmedText.replace(reNumber, '').trim()
+          title: trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ')
         };
 
         if (number) {

--- a/src/browserlib/map-ids-to-headings.js
+++ b/src/browserlib/map-ids-to-headings.js
@@ -61,7 +61,7 @@ export default function () {
 
       mappingTable[node.id] = {
         id,
-        title: trimmedText.replace(reNumber, '').trim()
+        title: trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ')
       };
 
       if (number) {


### PR DESCRIPTION
The titles of the headings could contain newlines and other non-significant spaces, as in "The\n  AbstractWorker mixin". They are now normalized to a proper space, as in "The AbstractWorker mixin".

Raised in https://github.com/mdn/browser-compat-data/issues/6765#issuecomment-722250789