### PR TITLE
Add "definedIn" property to dfns extract

### DIFF
--- a/builds/browser.js
+++ b/builds/browser.js
@@ -2670,6 +2670,12 @@ for more information.`;
    *     "private" when it should be viewed as a local definition.
    * - informative: true when definition appears in an informative section,
    *     false if it is normative
+   * - heading: Heading under which the term is to be found. An object with "id",
+   *     "title", and "number" properties
+   * - definedIn: An indication of where the definition appears in the spec. Value
+   *     can be one of "dt", "pre", "table", "heading", "note", "example", or
+   *     "prose" (last one indicates that definition appears in the main body of
+   *     the spec)
    *
    * @function
    * @public
@@ -2679,6 +2685,32 @@ for more information.`;
   function definitionMapper(el, idToHeading) {
     function normalize(str) {
       return str.trim().replace(/\s+/g, ' ');
+    }
+
+    let definedIn = 'prose';
+    const enclosingEl = el.closest('dt,pre,table,h1,h2,h3,h4,h5,h6,.note,.example') || el;
+    switch (enclosingEl.nodeName) {
+      case 'DT':
+      case 'PRE':
+      case 'TABLE':
+        definedIn = enclosingEl.nodeName.toLowerCase();
+        break;
+      case 'H1':
+      case 'H2':
+      case 'H3':
+      case 'H4':
+      case 'H5':
+      case 'H6':
+        definedIn = 'heading';
+        break;
+      default:
+        if (enclosingEl.classList.contains('note')) {
+          definedIn = 'note';
+        }
+        else if (enclosingEl.classList.contains('example')) {
+          definedIn = 'example';
+        }
+        break;
     }
 
     return {
@@ -2736,7 +2768,12 @@ for more information.`;
       ].join(',')),
 
       // Heading under which the term is to be found
-      heading: idToHeading[el.getAttribute('id')]
+      heading: idToHeading[el.getAttribute('id')],
+
+      // Enclosing element under which the definition appears. Value can be one of
+      // "dt", "pre", "table", "heading", "note", "example", or "prose" (last one
+      // indicates that definition appears in the main body of the specification)
+      definedIn
     };
   }
 

--- a/src/browserlib/extract-dfns.js
+++ b/src/browserlib/extract-dfns.js
@@ -16,6 +16,12 @@ import {parse} from "../../node_modules/webidl2/index.js";
  *     "private" when it should be viewed as a local definition.
  * - informative: true when definition appears in an informative section,
  *     false if it is normative
+ * - heading: Heading under which the term is to be found. An object with "id",
+ *     "title", and "number" properties
+ * - definedIn: An indication of where the definition appears in the spec. Value
+ *     can be one of "dt", "pre", "table", "heading", "note", "example", or
+ *     "prose" (last one indicates that definition appears in the main body of
+ *     the spec)
  *
  * @function
  * @public
@@ -25,6 +31,32 @@ import {parse} from "../../node_modules/webidl2/index.js";
 function definitionMapper(el, idToHeading) {
   function normalize(str) {
     return str.trim().replace(/\s+/g, ' ');
+  }
+
+  let definedIn = 'prose';
+  const enclosingEl = el.closest('dt,pre,table,h1,h2,h3,h4,h5,h6,.note,.example') || el;
+  switch (enclosingEl.nodeName) {
+    case 'DT':
+    case 'PRE':
+    case 'TABLE':
+      definedIn = enclosingEl.nodeName.toLowerCase();
+      break;
+    case 'H1':
+    case 'H2':
+    case 'H3':
+    case 'H4':
+    case 'H5':
+    case 'H6':
+      definedIn = 'heading';
+      break;
+    default:
+      if (enclosingEl.classList.contains('note')) {
+        definedIn = 'note';
+      }
+      else if (enclosingEl.classList.contains('example')) {
+        definedIn = 'example';
+      }
+      break;
   }
 
   return {
@@ -82,7 +114,12 @@ function definitionMapper(el, idToHeading) {
     ].join(',')),
 
     // Heading under which the term is to be found
-    heading: idToHeading[el.getAttribute('id')]
+    heading: idToHeading[el.getAttribute('id')],
+
+    // Enclosing element under which the definition appears. Value can be one of
+    // "dt", "pre", "table", "heading", "note", "example", or "prose" (last one
+    // indicates that definition appears in the main body of the specification)
+    definedIn
   };
 }
 

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -53,7 +53,8 @@
         "type": "dfn",
         "for": [],
         "access": "private",
-        "informative": false
+        "informative": false,
+        "definedIn": "prose"
       }
     ],
     "headings": [
@@ -131,7 +132,8 @@
         "heading": {
           "id": "title",
           "title": "No Title"
-        }
+        },
+        "definedIn": "pre"
       },
       {
         "id": "dom-foo-bar",
@@ -151,7 +153,8 @@
         "heading": {
           "id": "title",
           "title": "No Title"
-        }
+        },
+        "definedIn": "pre"
       }
     ],
     "headings": [

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -45,7 +45,8 @@ nock("https://respec.org")
 
 nock("https://specref.herokuapp.com")
   .persist()
-  .get("/bibrefs?refs=webidl,html").reply(200, {webidl:{href:"https://heycam.github.io/webidl/"}}, {"Access-Control-Allow-Origin": "*"});
+  .get("/bibrefs?refs=webidl,html").reply(200, {webidl:{href:"https://heycam.github.io/webidl/"}}, {"Access-Control-Allow-Origin": "*"})
+  .get("/bibrefs?refs=HTML").reply(200, {HTML:{href:"https://html.spec.whatwg.org/multipage/"}}, {"Access-Control-Allow-Origin": "*"});
 
 nock("https://www.w3.org")
   .persist()

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -85,7 +85,8 @@ const baseDfn = {
     type: 'dfn',
     for: [],
     access: 'private',
-    informative: false
+    informative: false,
+    definedIn: 'prose'
 };
 const tests = [
   {title: "parses a simple <dfn>",
@@ -123,7 +124,7 @@ const tests = [
   },
   {title: "considers definitions in headings",
    html: "<h2 data-dfn-type=dfn id=foo>Foo</h2>",
-   changesToBaseDfn: [{heading: { id: "foo", title: "Foo"}}]
+   changesToBaseDfn: [{heading: { id: "foo", title: "Foo"}, definedIn: "heading"}]
   },
   {title: "ignores elements that aren't <dfn> and headings",
    html: "<span data-dfn-type=dfn id=foo>Foo</span>",
@@ -147,7 +148,8 @@ const tests = [
            access: "public",
            type: "element",
            linkingText: ["html"],
-           heading: { id: "the-html-element", title: "The html element", number: "4.1.1"}}],
+           heading: { id: "the-html-element", title: "The html element", number: "4.1.1"},
+           definedIn: "heading"}],
    spec: "html"
   },
   {title: "handles exceptions in the HTML spec convention for defining elements",
@@ -156,14 +158,16 @@ const tests = [
            access: "public",
            type: "element",
            linkingText: ["video"],
-           heading: { id: "the-video-element", title: "The video element", number: "4.8.9"}}],
+           heading: { id: "the-video-element", title: "The video element", number: "4.8.9"},
+           definedIn: "heading"}],
    spec: "html"
   },
   {title: "handles HTML spec conventions of definitions in headings",
    html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',
    changesToBaseDfn: [{id: "parsing-main-inselect",
            linkingText: ["in select"],
-           heading: { id: "parsing-main-inselect", title: "The \"in select\" insertion mode", number: "12.2.6.4.16"}}],
+           heading: { id: "parsing-main-inselect", title: "The \"in select\" insertion mode", number: "12.2.6.4.16"},
+           definedIn: "heading"}],
    spec: "html"
   },
   {title: "handles HTML spec convention for defining element interfaces",
@@ -171,7 +175,8 @@ const tests = [
    changesToBaseDfn: [{id: "htmlhrelement",
            access: "public",
            type: "interface",
-           linkingText: ["HTMLHRElement"]}],
+           linkingText: ["HTMLHRElement"],
+           definedIn: "pre"}],
    spec: "html"
   },
   {title: "handles finding IDL type across mixins and partial",
@@ -187,7 +192,8 @@ const tests = [
    html: '<dt><dfn id="selector-visited" data-noexport=""><code>:visited</code></dfn></dt>',
    changesToBaseDfn: [{id: "selector-visited",
            type: "selector",
-           linkingText: [":visited"]}],
+           linkingText: [":visited"],
+           definedIn: "dt"}],
    spec: "html"
   },
   {
@@ -274,7 +280,8 @@ const tests = [
             access: "public",
             type: "dict-member",
             linkingText: ["withCredentials"],
-            for: ['EventSourceInit']}],
+            for: ['EventSourceInit'],
+            definedIn: "pre"}],
     spec: "html"
   },
   {
@@ -354,7 +361,8 @@ const tests = [
     changesToBaseDfn: [{
       id: "text/xml",
       linkingText: ["text/xml"],
-      href: "https://example.org/indices.html#text/xml"
+      href: "https://example.org/indices.html#text/xml",
+      definedIn: "dt"
     }],
     spec: "html"
   },
@@ -400,7 +408,8 @@ const tests = [
             "use",
             "video"
            ],
-      "access": "public"
+      "access": "public",
+      definedIn: "table"
     }],
     spec: "SVG2"
   },
@@ -412,7 +421,8 @@ const tests = [
       linkingText: ["link"],
       type: "element",
       access: "public",
-      heading: { id: "LinkElement", title: "External style sheets: the effect of the HTML ‘link’ element", number: "6.3"}
+      heading: { id: "LinkElement", title: "External style sheets: the effect of the HTML ‘link’ element", number: "6.3"},
+      definedIn: "heading"
     }],
     spec: "SVG2"
   },
@@ -424,7 +434,8 @@ const tests = [
       linkingText: ["patternUnits"],
       type: "element-attr",
       for: ["pattern"],
-      access: "public"
+      access: "public",
+      definedIn: "dt"
     }],
     spec: "SVG2"
   },
@@ -436,7 +447,8 @@ const tests = [
       linkingText: ["stop-opacity"],
       type: "property",
       for: ["stop"],
-      access: "public"
+      access: "public",
+      definedIn: "dt"
     }],
     spec: "SVG2"
   },
@@ -472,7 +484,8 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       linkingText: ["SVGAnimatedLengthList"],
       type: "interface",
       access: "public",
-      heading: { id: "InterfaceSVGAnimatedLengthList", title: "Interface SVGAnimatedLengthList", number: "4.6.10"}
+      heading: { id: "InterfaceSVGAnimatedLengthList", title: "Interface SVGAnimatedLengthList", number: "4.6.10"},
+      definedIn: "heading"
     }],
     spec: "SVG2"
   },
@@ -490,7 +503,8 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       id: "SVGBoundingBoxOptions",
       linkingText: ["SVGBoundingBoxOptions"],
       type: "dictionary",
-      access: "public"
+      access: "public",
+      definedIn: "pre"
     }],
     spec :"SVG2",
   }


### PR DESCRIPTION
The `definedIn` property captures the context under which the definition appears in the specification. Value may be one of:
- "dt": appears in a `<dt>`
- "pre": appears in a `<pre>`
- "table": appears in a `<table>`
- "heading": appears in one of `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`
- "note": appears in a section flagged with a `note` class
- "example": appears in a section flagged with an `example` class
- "prose": appears elsewhere, typically in a paragraph.

This information is meant to be used for analysis purpose, e.g. to identify cases where a definition used by a spec is incorrectly defined in a Note, or where an IDL definition appears in an IDL block instead of in the prose of the specification.

Other projects may also perhaps use that information, likely in combination with `type`, to assess whether they should link to the definition itself or to the section that contains the definition. See related discussion in https://github.com/mdn/browser-compat-data/issues/6765#issuecomment-722322115

The classification may evolve based on feedback.